### PR TITLE
Implement native HDFS functions via the hadoopy module. Fixes #86.

### DIFF
--- a/lobster/cmssw/dataset.py
+++ b/lobster/cmssw/dataset.py
@@ -1,9 +1,8 @@
 from collections import defaultdict
-import glob
 import math
 import os
 import sys
-from lobster import util
+from lobster import util, fs
 
 sys.path.insert(0, '/cvmfs/cms.cern.ch/crab/CRAB_2_10_2_patch2/external/dbs3client')
 from dbs.apis.dbsClient import DbsApi
@@ -126,20 +125,19 @@ class FileInterface:
                     files = [files]
                 for entry in files:
                     entry = os.path.expanduser(entry)
-                    if os.path.isdir(entry):
-                        dset.files += [f for f in glob.glob(os.path.join(entry, '*'))]
-                    elif os.path.isfile(entry):
+                    if fs.isdir(entry):
+                        dset.files += [f for f in fs.ls(os.path.join(entry, '*'))]
+                    if fs.isfile(entry):
                         dset.files += [f.strip() for f in open(entry).readlines()]
                     elif isinstance(entry, str):
-                        dset.files += [f for f in glob.glob(os.path.join(entry))]
+                        dset.files += [f for f in fs.ls(os.path.join(entry))]
 
                 dset.total_lumis = len(dset.files)
 
                 for file in dset.files:
                     # hack because it will be slow to open all the input files to read the run/lumi info
                     dset.lumis[file] = [(-1, -1)]
-                    dset.filesizes[file] = os.path.getsize(file)
-
+                    dset.filesizes[file] = fs.getsize(file)
             self.__dsets[label] = dset
 
         return self.__dsets[label]

--- a/lobster/core.py
+++ b/lobster/core.py
@@ -11,7 +11,7 @@ import traceback
 import yaml
 import sqlite3
 
-from lobster import util, cmssw, job
+from lobster import cmssw, fs, job, util
 
 from pkg_resources import get_distribution
 

--- a/lobster/fs.py
+++ b/lobster/fs.py
@@ -1,0 +1,48 @@
+import glob
+import hadoopy
+import os
+
+def fs_handler(backup, *args, **kwargs):
+    def wrapper(func):
+        def call(path):
+            if path.startswith('/hadoop'):
+                return backup(path.replace('/hadoop', '', 1), *args, **kwargs)
+            else:
+                return func(path)
+        return call
+    return wrapper
+
+@fs_handler(hadoopy.exists)
+def exists(path):
+    return os.path.exists(path)
+
+@fs_handler(hadoopy.isdir)
+def isdir(path):
+    return os.path.isdir(path)
+
+@fs_handler(hadoopy.mkdir)
+def makedirs(path):
+    return os.makedirs(path)
+
+@fs_handler(hadoopy.stat, '%b')
+def getsize(path):
+    return os.path.getsize(path)
+
+def isfile(path):
+    if path.startswith('/hadoop'):
+        return hadoopy.stat(path.replace('/hadoop', '', 1), '%F') == 'regular file'
+    else:
+        return os.path.isfile(path)
+
+def ls(path):
+    res = glob.glob(path)
+
+    if len(res) == 0:
+        try:
+            res = ['/hadoop' + x for x in hadoopy.ls(path.replace('/hadoop', '', 1))]
+        except:
+            raise
+
+    return res
+
+

--- a/lobster/job.py
+++ b/lobster/job.py
@@ -12,7 +12,7 @@ import time
 
 from functools import partial
 from hashlib import sha1
-from lobster import chirp, util
+from lobster import chirp, fs, util
 
 logger = multiprocessing.get_logger()
 
@@ -88,21 +88,21 @@ class JobProvider(object):
             taskdir = os.path.join(self.workdir, label)
             stageoutdir = os.path.join(self.stageout, label)
             if create:
-                if not os.path.exists(taskdir):
-                    os.makedirs(taskdir)
+                if not fs.exists(taskdir):
+                    fs.makedirs(taskdir)
                 if chirp_root and stageoutdir.startswith(chirp_root):
                     target = stageoutdir.replace(chirp_root, '', 1)
                     if not chirp.exists(chirp_server, chirp_root, target):
                         chirp.makedirs(chirp_server, chirp_root, target)
                 else:
-                    if not os.path.exists(stageoutdir):
-                        os.makedirs(stageoutdir)
+                    if not fs.exists(stageoutdir):
+                        fs.makedirs(stageoutdir)
 
                 shutil.copy(self.config['filename'], os.path.join(self.workdir, 'lobster_config.yaml'))
 
         for p in (self.parrot_bin, self.parrot_lib):
-            if not os.path.exists(p):
-                os.makedirs(p)
+            if not fs.exists(p):
+                fs.makedirs(p)
 
         for exe in ('parrot_run', 'chirp', 'chirp_put', 'chirp_get'):
             shutil.copy(util.which(exe), self.parrot_bin)
@@ -117,8 +117,8 @@ class JobProvider(object):
 
     def create_jobdir(self, jobid, label, status='running'):
         jdir = self.get_jobdir(jobid, label, status)
-        if not os.path.isdir(jdir):
-            os.makedirs(jdir)
+        if not fs.isdir(jdir):
+            fs.makedirs(jdir)
         return jdir
 
     def move_jobdir(self, jobid, label, status, oldstatus='running'):
@@ -132,8 +132,8 @@ class JobProvider(object):
         old = self.get_jobdir(jobid, label, oldstatus)
         new = self.get_jobdir(jobid, label, status)
         parent = os.path.dirname(new)
-        if not os.path.isdir(parent):
-            os.makedirs(parent)
+        if not fs.isdir(parent):
+            fs.makedirs(parent)
         shutil.move(old, parent)
         if len(os.listdir(os.path.dirname(old))) == 0:
             os.removedirs(os.path.dirname(old))

--- a/setup.py
+++ b/setup.py
@@ -22,12 +22,14 @@ setup(
     install_requires=[
         'argparse',
         'jinja2',
+        'hadoopy',
         'nose',
         'pyyaml',
         'python-daemon',
         'python-dateutil',
         'pytz'
     ],
+    dependency_links=['git+https://github.com/bwhite/hadoopy#egg=hadoopy'],
     entry_points={
         'console_scripts': ['lobster = lobster.ui:boil']
     }


### PR DESCRIPTION
This is not a very elegant solution-- I don't know how to detect HDFS endpoints except testing for a leading ‘hadoop' and making sure that all lobster.fs functions preserve the leading ‘hadoop.' But it works, so I think we should keep it as a starting point. I will merge this PR tomorrow unless there are any objections.