### PR TITLE
Implement SRM stage-out for tasks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,25 @@ The last line of arguments corresponds to the desired worker configuration.
 
 # Advanced usage
 
-## Stage-out via chirp
+## Stage-out
+
+### Via SRM
+
+Lobster supports SRM stage-out.  Parameters for SRM stage-out can be found
+in `/cvmfs/cms.cern.ch/SITECONFIG`, the directory of the destination
+storage element, file `PhEDEx/storage.xml`.  A `lfn-to-pfn` leaf with the
+`srmv2` protocol will reveal the server URL, which should be used in the
+configuration, without any `$1`.  For example, the adjusted settings for
+`T3_US_ND` are:
+
+    srm url: "srm://ndcms.crc.nd.edu:8443/srm/v2/server?SFN=/hadoop/"
+    srm root: "/hadoop/"
+
+The `srm root` maps the physical file name to the logical file name.  Both
+the `srm url` and `srm root` should be adjusted such that the logical file
+name can be appended to the `srm url` without any problem.
+
+### Via chirp
 
 Using chirp for stage-in and stage-out can be helpful when standard CMS
 tools for file handling, i.e., XrootD and SRM, are not available.

--- a/lobster/cmssw/data/job.py
+++ b/lobster/cmssw/data/job.py
@@ -222,10 +222,10 @@ def copy_outputs(data, config, env):
 
             prg = []
 
-            if int(os.environ["LOBSTER_GFAL_COPY"]) == 1:
-                prg = ["env", "-i", "X509_USER_PROXY=proxy", "gfal-copy"]
-            elif int(os.environ["LOBSTER_LCG_CP"]) == 1:
-                prg = ["lcg-cp", "-b", "-v", "-D", "srmv2"]
+            if len(os.environ["LOBSTER_GFAL_COPY"]) > 0:
+                prg = ["env", "-i", "X509_USER_PROXY=proxy", os.environ["LOBSTER_GFAL_COPY"]]
+            elif len(os.environ["LOBSTER_LCG_CP"]) > 0:
+                prg = [os.environ["LOBSTER_LCG_CP"], "-b", "-v", "-D", "srmv2"]
             else:
                 raise RuntimeError("no stage-out method available")
 
@@ -238,9 +238,10 @@ def copy_outputs(data, config, env):
             print " ".join(args)
             print "---"
 
+            # FIXME is this really needed after simplifying the repos?
             pruned_env = dict(env)
-            for k in ['LD_LIBRARY_PATH', 'PATH']:
-                pruned_env[k] = ':'.join([x for x in os.environ[k].split(':') if 'CMSSW' not in x])
+            # for k in ['LD_LIBRARY_PATH', 'PATH']:
+            #     pruned_env[k] = ':'.join([x for x in os.environ[k].split(':') if 'CMSSW' not in x])
 
             p = subprocess.Popen(args, env=pruned_env, stderr=subprocess.PIPE)
             p.wait()

--- a/lobster/cmssw/data/job.py
+++ b/lobster/cmssw/data/job.py
@@ -248,6 +248,8 @@ def copy_outputs(data, config, env):
             if p.returncode != 0:
                 data['stageout exit code'] = p.returncode
                 raise IOError("Failed to transfer output file '{0}':\n{1}".format(localname, p.stderr.read()))
+            else:
+                print p.stderr.read()
         elif chirp_server:
             if chirp_root and remotename.startswith(chirp_root):
                 remotename = remotename.replace(chirp_root, '', 1)

--- a/lobster/cmssw/data/job.py
+++ b/lobster/cmssw/data/job.py
@@ -236,10 +236,11 @@ def copy_outputs(data, config, env):
             print " ".join(args)
             print "---"
 
-            status = subprocess.call(args, env=env)
-            if status != 0:
-                data['stageout exit code'] = status
-                raise IOError("Failed to transfer output file '{0}'".format(localname))
+            p = subprocess.Popen(args, env=env, stderr=subprocess.PIPE)
+            p.wait()
+            if p.returncode != 0:
+                data['stageout exit code'] = p.returncode
+                raise IOError("Failed to transfer output file '{0}':\n{1}".format(localname, p.stderr.read()))
         elif chirp_server:
             if chirp_root and remotename.startswith(chirp_root):
                 remotename = remotename.replace(chirp_root, '', 1)

--- a/lobster/cmssw/data/job.py
+++ b/lobster/cmssw/data/job.py
@@ -236,7 +236,11 @@ def copy_outputs(data, config, env):
             print " ".join(args)
             print "---"
 
-            p = subprocess.Popen(args, env=env, stderr=subprocess.PIPE)
+            pruned_env = env
+            for k in ['LD_LIBRARY_PATH', 'PATH']:
+                pruned_env[k] = ':'.join([x for x in os.environ[k].split(':') if 'CMSSW' not in x])
+
+            p = subprocess.Popen(args, env=pruned_env, stderr=subprocess.PIPE)
             p.wait()
             if p.returncode != 0:
                 data['stageout exit code'] = p.returncode

--- a/lobster/cmssw/data/job.py
+++ b/lobster/cmssw/data/job.py
@@ -70,8 +70,10 @@ def check_outputs(config):
     """Check that chirp received the output files.
     """
     chirp_server = config.get('chirp server', None)
+    srm_server = config.get('srm server', None)
 
-    if not chirp_server:
+    # Trust SRM to reliably copy output files
+    if srm_server or not chirp_server:
         return True
 
     for local, remote in config['output files']:

--- a/lobster/cmssw/data/job.py
+++ b/lobster/cmssw/data/job.py
@@ -238,7 +238,7 @@ def copy_outputs(data, config, env):
             print " ".join(args)
             print "---"
 
-            pruned_env = env
+            pruned_env = dict(env)
             for k in ['LD_LIBRARY_PATH', 'PATH']:
                 pruned_env[k] = ':'.join([x for x in os.environ[k].split(':') if 'CMSSW' not in x])
 

--- a/lobster/cmssw/data/job.py
+++ b/lobster/cmssw/data/job.py
@@ -225,7 +225,7 @@ def copy_outputs(data, config, env):
             if int(os.environ["LOBSTER_GFAL_COPY"]) == 1:
                 prg = ["env", "-i", "X509_USER_PROXY=proxy", "gfal-copy"]
             elif int(os.environ["LOBSTER_LCG_CP"]) == 1:
-                prg = ["lcg-cp", "-b", "-D", "srmv2"]
+                prg = ["lcg-cp", "-b", "-v", "-D", "srmv2"]
             else:
                 raise RuntimeError("no stage-out method available")
 

--- a/lobster/cmssw/data/job.py
+++ b/lobster/cmssw/data/job.py
@@ -222,10 +222,11 @@ def copy_outputs(data, config, env):
 
             prg = []
 
-            if len(os.environ["LOBSTER_GFAL_COPY"]) > 0:
-                prg = ["env", "-i", "X509_USER_PROXY=proxy", os.environ["LOBSTER_GFAL_COPY"]]
-            elif len(os.environ["LOBSTER_LCG_CP"]) > 0:
+            if len(os.environ["LOBSTER_LCG_CP"]) > 0:
                 prg = [os.environ["LOBSTER_LCG_CP"], "-b", "-v", "-D", "srmv2"]
+            elif len(os.environ["LOBSTER_GFAL_COPY"]) > 0:
+                # FIXME gfal is very picky about its environment
+                prg = [os.environ["LOBSTER_GFAL_COPY"]]
             else:
                 raise RuntimeError("no stage-out method available")
 

--- a/lobster/cmssw/data/job.py
+++ b/lobster/cmssw/data/job.py
@@ -212,7 +212,9 @@ def copy_outputs(data, config, env):
             print error
             outsize_bare += os.path.getsize(localname)
 
-        if srm_server:
+        if os.path.isdir(os.path.dirname(remotename)):
+            shutil.copy2(localname, remotename)
+        elif srm_server:
             if srm_root and remotename.startswith(srm_root):
                 remotename = remotename.replace(srm_root, '', 1)
             if remotename.startswith('/'):

--- a/lobster/cmssw/data/mtab
+++ b/lobster/cmssw/data/mtab
@@ -1,1 +1,0 @@
-/cvmfs/cms.cern.ch/SITECONF/local/	siteconfig

--- a/lobster/cmssw/data/wrapper.sh
+++ b/lobster/cmssw/data/wrapper.sh
@@ -107,10 +107,7 @@ source /cvmfs/cms.cern.ch/cmsset_default.sh
 
 if [[ -z "$LOBSTER_PROXY_INFO" || ( -z "$LOBSTER_LCG_CP" && -z "$LOBSTER_GFAL_COPY" ) ]]; then
 	echo ">>> sourcing OSG setup"
-	# FIXME this fixes broken symlinks in CVMFS
-	# TODO source proper setup script
-	# source /cvmfs/oasis.opensciencegrid.org/mis/osg-wn-client/3.2/3.2.23/el6-$(uname -m)/setup.sh
-	source /cvmfs/oasis.opensciencegrid.org/mis/osg-wn-client/3.1/3.1.46/el6-$(uname -m)/setup.sh
+	source /cvmfs/oasis.opensciencegrid.org/osg-software/osg-wn-client/3.2/current/el6-$(uname -m)/setup.sh
 
 	[ -z "$LOBSTER_LCG_CP" ] && export LOBSTER_LCG_CP=$(command -v lcg-cp)
 	[ -z "$LOBSTER_GFAL_COPY" ] && export LOBSTER_GFAL_COPY=$(command -v gfal-copy)

--- a/lobster/cmssw/data/wrapper.sh
+++ b/lobster/cmssw/data/wrapper.sh
@@ -41,16 +41,8 @@ fi
 if [ "x$PARROT_ENABLED" != "x" ]; then
 	echo "=parrot= True"
 else
-	# test for stage-out availability
-	LOBSTER_LCG_CP=0
-	LOBSTER_GFAL_COPY=0
-	command -v lcg-cp > /dev/null 2>&1 && LOBSTER_LCG_CP=1
-	command -v gfal-copy > /dev/null 2>&1 && LOBSTER_LCG_CP=1
-	export LOBSTER_LCG_CP LOBSTER_GFAL_COPY
-	
 	if [[ ! ( -f "/cvmfs/cms.cern.ch/cmsset_default.sh" \
 			&& -f /cvmfs/grid.cern.ch/3.2.11-1/etc/profile.d/grid-env.sh \
-			&& ( $LOBSTER_GFAL_COPY > 0 || $LOBSTER_LCG_CP > 0 ) \
 			&& -f /cvmfs/cms.cern.ch/SITECONF/local/JobConfig/site-local-config.xml) ]]; then
 		if [ -f /etc/cvmfs/default.local ]; then
 			print_output "trying to determine proxy with" cat /etc/cvmfs/default.local
@@ -81,8 +73,7 @@ else
 		export PARROT_PATH=${PARROT_PATH:-./bin}
 		export PARROT_CVMFS_REPO=\
 '*:try_local_filesystem
-*.cern.ch:pubkey=<BUILTIN-cern.ch.pub>,url=http://cvmfs.fnal.gov:8000/opt/*
-*.opensciencegrid.org:pubkey=<BUILTIN-opensciencegrid.org.pub>,url=http://oasis-replica.opensciencegrid.org:8000/cvmfs/*;http://cvmfs.fnal.gov:8000/cvmfs/*;http://cvmfs.racf.bnl.gov:8000/cvmfs/*'
+*.cern.ch:pubkey=<BUILTIN-cern.ch.pub>,url=http://cvmfs.fnal.gov:8000/opt/*'
 
 		export PARROT_ALLOW_SWITCHING_CVMFS_REPOSITORIES=TRUE
 		export PARROT_CACHE=$TMPDIR
@@ -100,17 +91,19 @@ else
 		fi
 
 		echo ">>> starting parrot to access CMSSW..."
-		exec $PARROT_PATH/parrot_run -m mtab -t "$PARROT_CACHE/ex_parrot_$(whoami)" bash $0 "$*"
+		exec $PARROT_PATH/parrot_run -M /cvmfs/cms.cern.ch/SITECONF/local=$PWD/siteconfig -t "$PARROT_CACHE/ex_parrot_$(whoami)" bash $0 "$*"
 	fi
 fi
 
-if [[ $LOBSTER_GFAL_COPY == 0 && $LOBSTER_LCG_CP == 0 ]]; then
-	echo ">>>> sourcing OSG lcg-cp"
-	source /cvmfs/oasis.opensciencegrid.org/osg-software/osg-wn-client/3.2/current/el6-$(uname -m)/setup.sh
-	export LOBSTER_LCG_CP=1
-fi
 source /cvmfs/cms.cern.ch/cmsset_default.sh
 source /cvmfs/grid.cern.ch/3.2.11-1/etc/profile.d/grid-env.sh
+
+# test for stage-out availability
+LOBSTER_LCG_CP=0
+LOBSTER_GFAL_COPY=0
+command -v lcg-cp > /dev/null 2>&1 && LOBSTER_LCG_CP=1
+command -v gfal-copy > /dev/null 2>&1 && LOBSTER_LCG_CP=1
+export LOBSTER_LCG_CP LOBSTER_GFAL_COPY
 
 print_output "environment after sourcing startup scripts" env\|sort
 print_output "proxy information" env X509_USER_PROXY=proxy voms-proxy-info

--- a/lobster/cmssw/data/wrapper.sh
+++ b/lobster/cmssw/data/wrapper.sh
@@ -73,7 +73,6 @@ elif [[ ! ( -f "/cvmfs/cms.cern.ch/cmsset_default.sh" \
 	export HTTP_PROXY=${HTTP_PROXY:-http://eddie.crc.nd.edu:3128}
 	export HTTP_PROXY=$(echo $HTTP_PROXY|perl -ple 's/(?<=:\/\/)([^|:;]+)/@ls=split(\/\s\/,`nslookup $1`);$ls[-1]||$1/eg')
 	echo ">>> using CVMFS proxy: $HTTP_PROXY"
-	export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
 
 	# These are allowed to be modified via the environment
 	# passed to the job (e.g. via condor)
@@ -100,7 +99,7 @@ elif [[ ! ( -f "/cvmfs/cms.cern.ch/cmsset_default.sh" \
 	fi
 
 	echo ">>> starting parrot to access CMSSW..."
-	exec $PARROT_PATH/parrot_run -M /etc/grid-security/certificates=/afs/crc.nd.edu/user/m/mwolf3/certs -M /cvmfs/cms.cern.ch/SITECONF/local=$PWD/siteconfig -t "$PARROT_CACHE/ex_parrot_$(whoami)" bash $0 "$*"
+	exec $PARROT_PATH/parrot_run -M /cvmfs/cms.cern.ch/SITECONF/local=$PWD/siteconfig -t "$PARROT_CACHE/ex_parrot_$(whoami)" bash $0 "$*"
 fi
 
 echo ">>> sourcing CMS setup"

--- a/lobster/cmssw/job.py
+++ b/lobster/cmssw/job.py
@@ -293,7 +293,6 @@ class JobProvider(job.JobProvider):
             ids.append(id)
 
             inputs = [(self.__sandbox + ".tar.bz2", "sandbox.tar.bz2", True),
-                      (os.path.join(os.path.dirname(__file__), 'data', 'mtab'), 'mtab', True),
                       (os.path.join(os.path.dirname(__file__), 'data', 'siteconfig'), 'siteconfig', True),
                       (os.path.join(os.path.dirname(__file__), 'data', 'wrapper.sh'), 'wrapper.sh', True),
                       (self.parrot_bin, 'bin', None),

--- a/lobster/cmssw/job.py
+++ b/lobster/cmssw/job.py
@@ -195,6 +195,9 @@ class JobProvider(job.JobProvider):
         self.__chirp = self.config.get('chirp server', None)
         self.__chirp_root = self.config.get('chirp root', self.stageout) if self.__chirp else None
 
+        self.__srm = self.config.get('srm url', None)
+        self.__srm_root = self.config.get('srm root' '') if self.__srm else None
+
         if self.__chirp:
             try:
                 chirp.get_chirp_output(self.__chirp, args=['ls', '/'], timeout=5, throw=True)
@@ -426,6 +429,8 @@ class JobProvider(job.JobProvider):
                     'arguments': args,
                     'chirp server': self.__chirp,
                     'chirp root': self.__chirp_root,
+                    'srm server': self.__srm,
+                    'srm root': self.__srm_root,
                     'xrootd server': self.__xrootd,
                     'xrootd root': self.__xrootd_root,
                     'output files': stageout,


### PR DESCRIPTION
This currently only allows the tasks to stage their files out via SRM.  The
master has no SRM connection to the storage element.  Fixes #98.

Uses either gfal-copy, if available, or lcg-cp, which is deprecated,
but more widespread in use.

@annawoodard any comments?  Do you want to test this?
@klannon this may need some fine-tuning for cms-connect, depending on the site configuration.