### PR TITLE
 Rework job cancellation.

### DIFF
--- a/lobster/cmssw/dash.py
+++ b/lobster/cmssw/dash.py
@@ -17,6 +17,7 @@ SUBMITTED = 'Pending'
 DONE = 'Done'
 RETRIEVED = 'Retrieved'
 ABORTED = 'Aborted'
+CANCELLED = 'Killed'
 RUNNING = 'Running'
 WAITING_RETRIEVAL = 'Waiting Retrieval'
 

--- a/lobster/cmssw/job.py
+++ b/lobster/cmssw/job.py
@@ -559,6 +559,10 @@ class JobProvider(job.JobProvider):
         if len(jobs) > 0:
             self.retry(self.__store.update_jobits, (jobs,), {})
 
+    def terminate(self):
+        for id in self.__store.running_jobs():
+            self.__dash.update_job(str(id), dash.CANCELLED)
+
     def done(self):
         left = self.__store.unfinished_jobits()
         if self.config.get('merge size', -1) > 0:

--- a/lobster/cmssw/jobit.py
+++ b/lobster/cmssw/jobit.py
@@ -618,6 +618,11 @@ class JobitStore:
 
         return cur
 
+    def running_jobs(self):
+        cur = self.db.execute("select id from jobs where status=1")
+        for (v,) in cur:
+            yield v
+
     def update_pset_hash(self, pset_hash, dataset):
         self.db.execute("update datasets set pset_hash=? where label=?", (pset_hash, dataset))
 

--- a/lobster/job.py
+++ b/lobster/job.py
@@ -153,7 +153,10 @@ class JobProvider(object):
     def obtain(self):
         raise NotImplementedError
 
-    def release(self, id, return_code, output, task):
+    def release(self, tasks):
+        raise NotImplementedError
+
+    def terminate(self):
         raise NotImplementedError
 
     def work_left(self):
@@ -224,6 +227,9 @@ class SimpleJobProvider(JobProvider):
                 f = gzip.open(os.path.join(self.workdir, label, id+'_job.log.gz'), 'wb')
                 f.write(task.output)
                 f.close()
+
+    def terminate(self):
+        pass
 
     def work_left(self):
         return self.__max - self.__done


### PR DESCRIPTION
Upon lobster termination, call a method in the job source, which for CMS
jobs sets the dashboard status to 'killed'.  They then show up in the
dashboard page as 'Cancelled' instead of 'Failed'.

Removes duplicated job reporting and moves it from `core.py` to the JobProvider.

Fixes #105.