### PR TITLE
Move more stuff to the fs module.

### DIFF
--- a/lobster/cmssw/job.py
+++ b/lobster/cmssw/job.py
@@ -377,7 +377,7 @@ class JobProvider(job.JobProvider):
                 base, ext = os.path.splitext(filename)
                 outname = self.outputformats[label].format(base=base, ext=ext[1:], id=id)
 
-                handler.outputs.append(os.path.join(label, outname))
+                handler.outputs.append(os.path.join(self.stageout, label, outname))
                 stageout.append((filename, os.path.join(self.stageout, label, outname)))
                 if not self.__chirp:
                     outputs.append((os.path.join(sdir, outname), filename))
@@ -536,7 +536,12 @@ class JobProvider(job.JobProvider):
         self.__dash.free()
 
         for f in cleanup:
-            fs.remove(f)
+            try:
+                fs.remove(f)
+            except IOError:
+                pass
+            except OSError:
+                pass
         if len(jobs) > 0:
             self.retry(self.__store.update_jobits, (jobs,), {})
 

--- a/lobster/cmssw/job.py
+++ b/lobster/cmssw/job.py
@@ -9,7 +9,7 @@ import shutil
 import subprocess
 import sys
 
-from lobster import chirp, job, util
+from lobster import chirp, fs, job, util
 import dash
 import sandbox
 
@@ -200,8 +200,6 @@ class JobProvider(job.JobProvider):
 
         self.__sandbox = os.path.join(self.workdir, 'sandbox')
 
-        self.__unlinker = chirp.Unlinker(self.stageout, self.__chirp)
-
         self.__events = {}
         self.__configs = {}
         self.__local = {}
@@ -324,7 +322,7 @@ class JobProvider(job.JobProvider):
                     base, ext = os.path.splitext(self.outputs[label][0])
                     input = os.path.join(sdir, self.outputformats[label].format(base=base, ext=ext[1:], id=job))
 
-                    if os.path.isfile(report) and chirp.isfile(self.__chirp, self.__chirp_root, input):
+                    if os.path.isfile(report) and fs.isfile(input):
                         inreports.append(report)
                         infiles.append((job, input))
                         # FIXME we can also read files locally
@@ -545,8 +543,8 @@ class JobProvider(job.JobProvider):
 
         self.__dash.free()
 
-        if len(cleanup) > 0:
-            self.__unlinker.remove(cleanup)
+        for f in cleanup:
+            fs.remove(f)
         if len(jobs) > 0:
             self.retry(self.__store.update_jobits, (jobs,), {})
 

--- a/lobster/fs.py
+++ b/lobster/fs.py
@@ -2,8 +2,11 @@ import glob
 import hadoopy
 import os
 
+from functools import wraps
+
 def fs_handler(backup, *args, **kwargs):
     def wrapper(func):
+        @wraps(func)
         def call(path):
             if path.startswith('/hadoop'):
                 return backup(path.replace('/hadoop', '', 1), *args, **kwargs)
@@ -23,6 +26,10 @@ def isdir(path):
 @fs_handler(hadoopy.mkdir)
 def makedirs(path):
     return os.makedirs(path)
+
+@fs_handler(hadoopy.rmr)
+def remove(path):
+    return os.remove(path)
 
 @fs_handler(hadoopy.stat, '%b')
 def getsize(path):


### PR DESCRIPTION
Moves more usage of the `chirp` module to the `fs` one.  All the `chirp` module is good for then is the chirp server availability check.

Should fix #113.