### PR TITLE
Handle task results from WQ. Fixes #80.

### DIFF
--- a/doc/ErrorCodes.md
+++ b/doc/ErrorCodes.md
@@ -4,6 +4,10 @@ Lobster uses the following error codes:
 
 | Code | Reason
 | :--- | :-----
+|  4   | The task ran but its stdout has been truncated
+|  8   | The task was terminated with a signal
+|  16  | The task used more resources than requested
+|  32  | The task ran after specified end time
 |  169 | Unable to run parrot
 |  170 | Sandbox unpacking failure
 |  171 | Failed to determine base release

--- a/lobster/cmssw/job.py
+++ b/lobster/cmssw/job.py
@@ -19,6 +19,8 @@ from dataset import MetaInterface
 from FWCore.PythonUtilities.LumiList import LumiList
 from ProdCommon.CMSConfigTools.ConfigAPI.CfgInterface import CfgInterface
 
+import work_queue as wq
+
 logger = multiprocessing.get_logger()
 
 class JobHandler(object):
@@ -481,7 +483,13 @@ class JobProvider(job.JobProvider):
                 failed = True
                 logger.error("error processing {0}:\n{1}".format(task.tag, e))
 
-            if cmssw_exit_code not in (None, 0):
+            if task.result in [wq.WORK_QUEUE_RESULT_STDOUT_MISSING,
+                    wq.WORK_QUEUE_RESULT_SIGNAL,
+                    wq.WORK_QUEUE_RESULT_RESOURCE_EXHAUSTION,
+                    wq.WORK_QUEUE_RESULT_TASK_TIMEOUT]:
+                exit_code = task.result
+                failed = True
+            elif cmssw_exit_code not in (None, 0):
                 exit_code = cmssw_exit_code
                 if exit_code > 0:
                     failed = True


### PR DESCRIPTION
I believe this is the correct subset of WQ results for which we
want the WQ result to trump whatever exit code we're returning. For
missing files (wq.WORK_QUEUE_RESULT_{INPUT|OUTPUT}_MISSING, let's
handle it on our side (trust the wrapper to return a sensible exit
code), as it gives us more control.