### PR TITLE
Change hot cache behavior.

### DIFF
--- a/lobster/cmssw/data/wrapper.sh
+++ b/lobster/cmssw/data/wrapper.sh
@@ -178,7 +178,4 @@ print_output "working directory after execution" ls -l
 
 echo "[$(date '+%F %T')] wrapper done"
 
-if [ "x$PARROT_ENABLED" != "x" ]; then
-    touch $PARROT_CACHE/hot_cache
-fi
 exit $res


### PR DESCRIPTION
Moves the hot cache check to compare against a file with a timestamp:
The first finished job records its time of the processing of the first
event (CMS jobs) or its end time (all others).  Consecutive jobs compare
their startup time to said time, and report themselves as "hot" when their
wrapper start time lies beyond the cache flag time.

Fixes #157.