### PR TITLE
Add new class for storing job update info. Fixes #173.

### DIFF
--- a/lobster/cmssw/job.py
+++ b/lobster/cmssw/job.py
@@ -98,8 +98,7 @@ class JobHandler(object):
         file_update = []
         jobit_update = []
 
-        jobits_processed = 0
-        jobits_missed = 0
+        jobits_processed = len(self._jobits)
 
         for (id, file) in self._files:
             file_jobits = [tpl for tpl in self._jobits if tpl[1] == id]
@@ -113,24 +112,21 @@ class JobHandler(object):
 
             events_read += read
 
-            if not failed:
+            if failed:
+                jobits_processed = 0
+            else:
                 if skipped:
                     for (lumi_id, lumi_file, r, l) in file_jobits:
                         jobit_update.append((jobit.FAILED, lumi_id))
-                        jobits_missed += 1
+                        jobits_processed -= 1
                 elif not self._file_based:
                     file_lumis = set(map(tuple, files_info[file][1]))
                     for (lumi_id, lumi_file, r, l) in file_jobits:
                         if (r, l) not in file_lumis:
                             jobit_update.append((jobit.FAILED, lumi_id))
-                            jobits_missed += 1
+                            jobits_processed -= 1
 
             file_update.append((read, 1 if skipped else 0, id))
-
-        if not self._file_based:
-            jobits_missed = len(self._jobits) if failed else jobits_missed
-        else:
-            jobits_missed = len(self._files) - len(files_info.keys())
 
         if failed:
             events_written = 0
@@ -143,7 +139,7 @@ class JobHandler(object):
             # FIXME not correct
             jobits_missed = 0
 
-        return [jobits_missed, events_read, events_written, status], \
+        return jobits_processed, events_read, events_written, status, \
                 file_update, jobit_update
 
     def update_job(self, parameters, inputs, outputs, se):
@@ -487,33 +483,37 @@ class JobProvider(job.JobProvider):
                 f.write(task.output)
                 f.close()
 
+            job_update = jobit.JobUpdate()
             files_info = {}
             files_skipped = []
-            events_written = 0
-            task_times = [None] * 10
             cmssw_exit_code = None
-            cputime = 0
-            outsize = 0
-            outsize_bare = 0
-            cache_start_size = 0
-            cache_end_size = 0
-            cache = None
-
+            events_written = 0
             try:
                 with open(os.path.join(handler.jobdir, 'report.json'), 'r') as f:
                     data = json.load(f)
-                    cache_start_size = data['cache']['start size']
-                    cache_end_size = data['cache']['end size']
-                    cache = data['cache']['type']
-                    task_times = data['task timing info']
+                    job_update.time_wrapper_start = data['task timing info'][0]
+                    job_update.time_wrapper_ready = data['task timing info'][1]
+                    job_update.time_stage_in_end = data['task timing info'][2]
+                    job_update.time_prologue_end = data['task timing info'][3]
+                    job_update.time_file_requested = data['task timing info'][4]
+                    job_update.time_file_opened = data['task timing info'][5]
+                    job_update.time_file_processing = data['task timing info'][6]
+                    job_update.time_processing_end = data['task timing info'][7]
+                    job_update.time_epilogue_end = data['task timing info'][8]
+                    job_update.time_stage_out_end = data['task timing info'][9]
+                    job_update.time_cpu = data['cpu time']
+                    job_update.cache_start_size = data['cache']['start size']
+                    job_update.cache_end_size = data['cache']['end size']
+                    job_update.cache = data['cache']['type']
+                    # input_protocol = data['input']['protocol']
+                    # output_protocol = data['output']['protocol']
                     if handler.cmssw_job:
                         files_info = data['files']['info']
                         files_skipped = data['files']['skipped']
                         events_written = data['events written']
                         cmssw_exit_code = data['cmssw exit code']
-                        cputime = data['cpu time']
-                        outsize = data['output size']
-                        outsize_bare = data['output bare size']
+                        job_update.bytes_output = data['output size']
+                        job_update.bytes_bare_output = data['output bare size']
             except (ValueError, EOFError, IOError) as e:
                 failed = True
                 logger.error("error processing {0}:\n{1}".format(task.tag, e))
@@ -533,33 +533,27 @@ class JobProvider(job.JobProvider):
 
             logger.info("job {0} returned with exit code {1}".format(task.tag, exit_code))
 
-            times = [
-                    task.submit_time / 1000000,
-                    task.send_input_start / 1000000,
-                    task.send_input_finish / 1000000
-                    ] + task_times + [
-                    task.receive_output_start / 1000000,
-                    task.receive_output_finish / 1000000,
-                    task.finish_time / 1000000,
-                    task.cmd_execution_time / 1000000,
-                    task.total_cmd_execution_time / 1000000,
-                    cputime
-                    ]
-            data = [
-                    cache_start_size,
-                    cache_end_size,
-                    cache,
-                    task.total_bytes_received,
-                    task.total_bytes_sent,
-                    outsize,
-                    outsize_bare
-                    ]
-
-            job_update, file_update, jobit_update = \
+            jobits_processed, events_read, events_written, status, file_update, jobit_update = \
                     handler.get_jobit_info(failed, files_info, files_skipped, events_written)
 
-            job_update = [util.verify_string(task.hostname), exit_code, task.total_submissions] \
-                    + times + data + job_update + [task.tag]
+            job_update.host = util.verify_string(task.hostname)
+            job_update.submissions = task.total_submissions
+            job_update.time_submit = task.submit_time / 1000000
+            job_update.time_transfer_in_start = task.send_input_start / 1000000
+            job_update.time_transfer_in_end = task.send_input_finish / 1000000
+            job_update.time_transfer_out_start = task.receive_output_start / 1000000
+            job_update.time_transfer_out_end = task.receive_output_finish / 1000000
+            job_update.time_retrieved = task.finish_time / 1000000
+            job_update.time_on_worker = task.cmd_execution_time / 1000000
+            job_update.time_total_on_worker = task.total_cmd_execution_time / 1000000
+            job_update.bytes_received = task.total_bytes_received
+            job_update.bytes_sent = task.total_bytes_sent
+            job_update.exit_code = exit_code
+            job_update.jobits_processed = jobits_processed
+            job_update.events_read = events_read
+            job_update.events_written = events_written
+            job_update.status = status
+            job_update.id = task.tag
 
             if failed:
                 faildir = self.move_jobdir(handler.id, handler.dataset, 'failed')

--- a/test/test_cms_backend.py
+++ b/test/test_cms_backend.py
@@ -2,6 +2,7 @@
 from lobster import cmssw
 from lobster.cmssw.dataset import DatasetInfo
 from lobster.cmssw.job import JobHandler
+from lobster.cmssw.jobit import JobUpdate
 import os
 import shutil
 import tempfile
@@ -147,11 +148,15 @@ class TestSQLBackend(object):
         files_skipped = []
         events_written = 123
 
-        job_update, file_update, lumi_update = handler.get_jobit_info(False, files_info, files_skipped, events_written)
+        jobits_processed, events_read, events_written, status, file_update, jobit_update = \
+                handler.get_jobit_info(False, files_info, files_skipped, events_written)
 
-        assert job_update == [0, 300, 123, 2]
+        assert jobits_processed == 4
+        assert events_read == 300
+        assert events_written == 123
+        assert status == 2
         assert file_update == [(220, 0, 1), (80, 0, 2)]
-        assert lumi_update == []
+        assert jobit_update == []
         # }}}
 
     def test_obtain(self):
@@ -186,13 +191,8 @@ class TestSQLBackend(object):
                     'test_good', lumis=20, filesize=2.2, jobsize=6))
         (id, label, files, lumis, arg, _, _) = self.interface.pop_jobits()[0]
 
-        data = [0] * 7
-        exit_code = 0
-        submissions = 0
-        times = [0] * 19
-
         handler = JobHandler(id, label, files, lumis, None, True)
-        job_update, file_update, lumi_update = \
+        jobits_processed, events_read, events_written, status, file_update, jobit_update = \
                 handler.get_jobit_info(
                         False,
                         {
@@ -203,9 +203,16 @@ class TestSQLBackend(object):
                         [],
                         100
                         )
-        job_update = ['hostname', exit_code, submissions] + times + data + job_update + [id]
 
-        self.interface.update_jobits({(label, "jobits_" + label): [(job_update, file_update, lumi_update)]})
+        job_update = JobUpdate(
+            events_read=events_read,
+            events_written=events_written,
+            host='hostname',
+            id=id,
+            jobits_processed=jobits_processed,
+            status=status)
+
+        self.interface.update_jobits({(label, "jobits_" + label): [(job_update, file_update, jobit_update)]})
 
         (jr, jd, er, ew) = self.interface.db.execute("""
             select
@@ -241,22 +248,27 @@ class TestSQLBackend(object):
         self.interface.register(*self.create_dbs_dataset('test_bad'))
         (id, label, files, lumis, arg, _, _) = self.interface.pop_jobits()[0]
 
-        data = [0] * 7
-        exit_code = 123
-        submissions = 1
-        times = [0] * 19
-
         handler = JobHandler(id, label, files, lumis, None, True)
-        job_update, file_update, lumi_update = \
+
+        jobits_processed, events_read, events_written, status, file_update, jobit_update = \
                 handler.get_jobit_info(
                         True,
                         {},
                         [],
                         0
                         )
-        job_update = ['hostname', exit_code, submissions] + times + data + job_update + [id]
 
-        self.interface.update_jobits({(label, "jobits_" + label): [(job_update, file_update, lumi_update)]})
+        job_update = JobUpdate(
+            events_read=events_read,
+            events_written=events_written,
+            exit_code=123,
+            host='hostname',
+            id=id,
+            jobits_processed=jobits_processed,
+            status=status,
+            submissions=1)
+
+        self.interface.update_jobits({(label, "jobits_" + label): [(job_update, file_update, jobit_update)]})
 
         (jr, jd, er, ew) = self.interface.db.execute("""
             select
@@ -286,13 +298,8 @@ class TestSQLBackend(object):
             'test_bad_again', lumis=20, filesize=2.2, jobsize=6))
         (id, label, files, lumis, arg, _, _) = self.interface.pop_jobits()[0]
 
-        data = [0] * 7
-        exit_code = 123
-        submissions = 1
-        times = [0] * 19
-
         handler = JobHandler(id, label, files, lumis, None, True)
-        job_update, file_update, lumi_update = \
+        jobits_processed, events_read, events_written, status, file_update, jobit_update = \
                 handler.get_jobit_info(
                         True,
                         {
@@ -304,9 +311,17 @@ class TestSQLBackend(object):
                         100
                         )
 
-        job_update = ['hostname', exit_code, submissions] + times + data + job_update + [id]
+        job_update = JobUpdate(
+            events_read=events_read,
+            events_written=events_written,
+            exit_code=123,
+            host='hostname',
+            id=id,
+            jobits_processed=jobits_processed,
+            status=status,
+            submissions=1)
 
-        self.interface.update_jobits({(label, "jobits_" + label): [(job_update, file_update, lumi_update)]})
+        self.interface.update_jobits({(label, "jobits_" + label): [(job_update, file_update, jobit_update)]})
 
         (jr, jd, er, ew) = self.interface.db.execute("""
             select
@@ -337,13 +352,8 @@ class TestSQLBackend(object):
                     'test_ugly', lumis=11, filesize=2.2, jobsize=6))
         (id, label, files, lumis, arg, _, _) = self.interface.pop_jobits()[0]
 
-        data = [0] * 7
-        exit_code = 0
-        submissions = 1
-        times = [0] * 19
-
         handler = JobHandler(id, label, files, lumis, None, True)
-        job_update, file_update, lumi_update = \
+        jobits_processed, events_read, events_written, status, file_update, jobit_update = \
                 handler.get_jobit_info(
                         False,
                         {
@@ -352,9 +362,16 @@ class TestSQLBackend(object):
                         ['/test/1.root', '/test/2.root'],
                         50
                         )
-        job_update = ['hostname', exit_code, submissions] + times + data + job_update + [id]
 
-        self.interface.update_jobits({(label, "jobits_" + label): [(job_update, file_update, lumi_update)]})
+        job_update = JobUpdate(
+            events_read=events_read,
+            events_written=events_written,
+            host='hostname',
+            id=id,
+            jobits_processed=jobits_processed,
+            status=status)
+
+        self.interface.update_jobits({(label, "jobits_" + label): [(job_update, file_update, jobit_update)]})
 
         skipped = list(
                 self.interface.db.execute(
@@ -404,13 +421,8 @@ class TestSQLBackend(object):
                     'test_uglier', lumis=11, filesize=2.2, jobsize=6))
         (id, label, files, lumis, arg, _, _) = self.interface.pop_jobits()[0]
 
-        data = [0] * 7
-        exit_code = 0
-        submissions = 1
-        times = [0] * 19
-
         handler = JobHandler(id, label, files, lumis, None, True)
-        job_update, file_update, lumi_update = \
+        jobits_processed, events_read, events_written, status, file_update, jobit_update = \
                 handler.get_jobit_info(
                         False,
                         {
@@ -420,15 +432,23 @@ class TestSQLBackend(object):
                         ['/test/2.root'],
                         100
                         )
-        job_update = ['hostname', exit_code, submissions] + times + data + job_update + [id]
 
-        self.interface.update_jobits({(label, "jobits_" + label): [(job_update, file_update, lumi_update)]})
+        job_update = JobUpdate(
+            events_read=events_read,
+            events_written=events_written,
+            host='hostname',
+            id=id,
+            jobits_processed=jobits_processed,
+            status=status,
+            submissions=1)
+
+        self.interface.update_jobits({(label, "jobits_" + label): [(job_update, file_update, jobit_update)]})
 
         # grab another job
         (id, label, files, lumis, arg, _, _) = self.interface.pop_jobits()[0]
 
         handler = JobHandler(id, label, files, lumis, None, True)
-        job_update, file_update, lumi_update = \
+        jobits_processed, events_read, events_written, status, file_update, jobit_update = \
                 handler.get_jobit_info(
                         False,
                         {
@@ -439,9 +459,14 @@ class TestSQLBackend(object):
                         [],
                         100
                         )
-        job_update = ['hostname', exit_code, submissions] + times + data + job_update + [id]
 
-        self.interface.update_jobits({(label, "jobits_" + label): [(job_update, file_update, lumi_update)]})
+        job_update.events_read = events_read
+        job_update.events_written = events_written
+        job_update.id = id
+        job_update.jobits_processed = jobits_processed
+        job_update.status = status
+
+        self.interface.update_jobits({(label, "jobits_" + label): [(job_update, file_update, jobit_update)]})
 
         (jr, jd, jl, er, ew) = self.interface.db.execute("""
             select
@@ -501,7 +526,7 @@ class TestSQLBackend(object):
         times = [0] * 19
 
         handler = JobHandler(id, label, files, lumis, None, True)
-        job_update, file_update, lumi_update = \
+        jobits_processed, events_read, events_written, status, file_update, jobit_update = \
                 handler.get_jobit_info(
                         False,
                         {
@@ -512,9 +537,16 @@ class TestSQLBackend(object):
                         [],
                         100
                         )
-        job_update = ['hostname', exit_code, submissions] + times + data + job_update + [id]
 
-        self.interface.update_jobits({(label, "jobits_" + label): [(job_update, file_update, lumi_update)]})
+        job_update = JobUpdate(
+            events_read=events_read,
+            events_written=events_written,
+            host='hostname',
+            id=id,
+            jobits_processed=jobits_processed,
+            status=status)
+
+        self.interface.update_jobits({(label, "jobits_" + label): [(job_update, file_update, jobit_update)]})
 
         (jr, jd, er, ew) = self.interface.db.execute("""
             select
@@ -539,22 +571,25 @@ class TestSQLBackend(object):
 
         (id, label, files, lumis, arg, _, _) = self.interface.pop_jobits()[0]
 
-        data = [0] * 7
-        exit_code = 1234
-        submissions = 0
-        times = [0] * 19
-
         handler = JobHandler(id, label, files, lumis, None, True)
-        job_update, file_update, lumi_update = \
+        jobits_processed, events_read, events_written, status, file_update, jobit_update = \
                 handler.get_jobit_info(
                         True,
                         {},
                         [],
                         0
                         )
-        job_update = ['hostname', exit_code, submissions] + times + data + job_update + [id]
 
-        self.interface.update_jobits({(label, "jobits_" + label): [(job_update, file_update, lumi_update)]})
+        job_update = JobUpdate(
+            events_read=events_read,
+            events_written=events_written,
+            exit_code=1234,
+            host='hostname',
+            id=id,
+            jobits_processed=jobits_processed,
+            status=status)
+
+        self.interface.update_jobits({(label, "jobits_" + label): [(job_update, file_update, jobit_update)]})
 
         (jr, jd, er, ew) = self.interface.db.execute("""
             select
@@ -579,13 +614,8 @@ class TestSQLBackend(object):
 
         (id, label, files, lumis, arg, _, _) = self.interface.pop_jobits()[0]
 
-        data = [0] * 7
-        exit_code = 0
-        submissions = 0
-        times = [0] * 19
-
         handler = JobHandler(id, label, files, lumis, None, True)
-        job_update, file_update, lumi_update = \
+        jobits_processed, events_read, events_written, status, file_update, jobit_update = \
                 handler.get_jobit_info(
                         False,
                         {
@@ -595,9 +625,16 @@ class TestSQLBackend(object):
                         ['/test/2.root'],
                         100
                         )
-        job_update = ['hostname', exit_code, submissions] + times + data + job_update + [id]
 
-        self.interface.update_jobits({(label, "jobits_" + label): [(job_update, file_update, lumi_update)]})
+        job_update = JobUpdate(
+            events_read=events_read,
+            events_written=events_written,
+            host='hostname',
+            id=id,
+            jobits_processed=jobits_processed,
+            status=status)
+
+        self.interface.update_jobits({(label, "jobits_" + label): [(job_update, file_update, jobit_update)]})
 
         (jr, jd, jl, er, ew) = self.interface.db.execute("""
             select

--- a/test/test_cms_backend.py
+++ b/test/test_cms_backend.py
@@ -166,12 +166,15 @@ class TestSQLBackend(object):
                     'test_obtain', lumis=20, filesize=2.2, jobsize=3))
         (id, label, files, lumis, arg, _, _) = self.interface.pop_jobits()[0]
 
-        (jr, jd, er, ew) = self.interface.db.execute(
-                "select jobits_running, jobits_done, (select sum(events_read) from jobs where status in (2, 6, 8) and type = 0 and dataset = datasets.id), (select sum(events_written) from jobs where status in (2, 6, 8) and type = 0 and dataset = datasets.id) from datasets where label=?",
-                (label,)
-                ).fetchone()
+        (jr, jd, er, ew) = self.interface.db.execute("""
+            select
+                jobits_running,
+                jobits_done,
+                (select sum(events_read) from jobs where status in (2, 6, 8) and type = 0 and dataset = datasets.id),
+                (select sum(events_written) from jobs where status in (2, 6, 8) and type = 0 and dataset = datasets.id)
+            from datasets where label=?""",
+            (label,)).fetchone()
 
-        print jr
         assert jr == 4
         assert jd == 0
         assert er in (0, None)


### PR DESCRIPTION
Actually, it's a function which returns a generic class, so it could be used to make other containers for updating the database.

This should improve the readability and make it easier to add
new tracked quantities to the job table.

I made it more namedtuple-inspired than dictionary-inspired because all of our queries are currently constructed to take tuples rather than dictionaries. This approach would probably be more flexible if we switched to dictionary-like syntax + a dictionary-like container, but lets make that change later if it becomes an issue. For now, I just couldn't stomach having to pick through that long update list trying to figure out which index goes to which quantity ever again.

I'm not sure if util.py is the right place for it, I'll wait and see what @matz-e thinks.