### PR TITLE
Fix handling of input files with AAA.

### DIFF
--- a/lobster/cmssw/data/job.py
+++ b/lobster/cmssw/data/job.py
@@ -194,7 +194,7 @@ def copy_inputs(data, config, env):
             config['file map'][file] = file
             print ">>> AAA access to input file detected:"
             print file
-            break
+            continue
 
         for input in config['input']:
             if os.path.exists(os.path.basename(file)):


### PR DESCRIPTION
Traverse all input files instead of just the first one when no input
transfer methods are specified.

Fixes #178.