### PR TITLE
Remove crab dependency

### DIFF
--- a/doc/CERN.md
+++ b/doc/CERN.md
@@ -18,8 +18,6 @@ version of the CC tools!
 Adjust your paths as follows:
 
     export PYTHONPATH=/afs/cern.ch/user/m/matze/src/cctools-002-b7289441-cvmfs-90fca639c-x86_64-redhat6/lib/python2.6/site-packages/:$PYTHONPATH
-    export PYTHONPATH=/cvmfs/cms.cern.ch/crab/CRAB_2_11_1/external:$PYTHONPATH
-    export PYTHONPATH=/cvmfs/cms.cern.ch/crab/CRAB_2_11_1/python:$PYTHONPATH
     export PATH=$PATH:/afs/cern.ch/user/m/matze/src/cctools-002-b7289441-cvmfs-90fca639c-x86_64-redhat6/bin
 
 ## Actually running

--- a/lobster/cmssw/dash.py
+++ b/lobster/cmssw/dash.py
@@ -1,12 +1,10 @@
 import datetime
-# import getpass
-# import pwd
+import logging
 import os
 import subprocess
 
 from hashlib import sha1
 
-import apmon
 from WMCore.Services.Dashboard.DashboardAPI import apmonSend, apmonFree
 from WMCore.Services.SiteDB.SiteDB import SiteDBJSON
 from lobster import util
@@ -95,7 +93,7 @@ class Monitor(DummyMonitor):
         apmonFree()
 
     def send(self, jobid, params):
-        apmonSend(self._taskid, jobid, params, apmon.Logger.ERROR, conf)
+        apmonSend(self._taskid, jobid, params, logging, conf)
 
     def register_run(self):
         self.send('TaskMeta', {

--- a/lobster/cmssw/dash.py
+++ b/lobster/cmssw/dash.py
@@ -6,7 +6,8 @@ import subprocess
 
 from hashlib import sha1
 
-from DashboardAPI import apmonSend, apmonFree
+import apmon
+from WMCore.Services.Dashboard.DashboardAPI import apmonSend, apmonFree
 from WMCore.Services.SiteDB.SiteDB import SiteDBJSON
 from lobster import util
 
@@ -33,6 +34,13 @@ status_map = {
     wq.WORK_QUEUE_TASK_CANCELED: ABORTED
 }
 
+conf = {
+        'cms-jobmon.cern.ch:8884': {
+            'sys_monitoring': 0,
+            'general_info': 0,
+            'job_monitoring': 0
+        }
+}
 
 class DummyMonitor(object):
     def __init__(self, workdir):
@@ -86,8 +94,11 @@ class Monitor(DummyMonitor):
     def free(self):
         apmonFree()
 
+    def send(self, jobid, params):
+        apmonSend(self._taskid, jobid, params, apmon.Logger.ERROR, conf)
+
     def register_run(self):
-        apmonSend(self._taskid, 'TaskMeta', {
+        self.send('TaskMeta', {
             'taskId': self._taskid,
             'jobId': 'TaskMeta',
             'tool': 'lobster',
@@ -109,7 +120,7 @@ class Monitor(DummyMonitor):
 
     def register_job(self, id):
         monitorid, syncid = self.generate_ids(id)
-        apmonSend(self._taskid, monitorid, {
+        self.send(monitorid, {
             'taskId': self._taskid,
             'jobId': monitorid,
             'sid': syncid,
@@ -136,7 +147,7 @@ class Monitor(DummyMonitor):
 
     def update_job(self, id, status):
         monitorid, syncid = self.generate_ids(id)
-        apmonSend(self._taskid, monitorid, {
+        self.send(monitorid, {
             'taskId': self._taskid,
             'jobId': monitorid,
             'sid': syncid,

--- a/lobster/cmssw/data/job.py
+++ b/lobster/cmssw/data/job.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 from datetime import datetime
 import gzip
 import json
+import logging
 import os
 import re
 import resource
@@ -17,14 +18,10 @@ ROOT.gROOT.SetBatch(True)
 ROOT.PyConfig.IgnoreCommandLineOptions = True
 ROOT.gErrorIgnoreLevel = ROOT.kError
 
-sys.path.insert(0, '/cvmfs/cms.cern.ch/crab/CRAB_2_10_5/external')
-
 from ROOT import TFile
-from DashboardAPI import apmonSend, apmonFree
 from FWCore.PythonUtilities.LumiList import LumiList
-from ProdCommon.FwkJobRep.FwkJobReport import FwkJobReport
-from ProdCommon.FwkJobRep.PerformanceReport import PerformanceReport
-from ProdCommon.FwkJobRep.ReportParser import readJobReport
+from WMCore.Services.Dashboard.DashboardAPI import apmonSend, apmonFree
+from WMCore.FwkJobReport.Report import Report
 
 
 fragment = """
@@ -41,6 +38,14 @@ if hasattr(process, 'options'):
 else:
     process.options = cms.untracked.PSet(wantSummary = cms.untracked.bool(True))
 """
+
+monalisa = {
+        'cms-jobmon.cern.ch:8884': {
+            'sys_monitoring': 0,
+            'general_info': 0,
+            'job_monitoring': 0
+        }
+}
 
 def run_subprocess(*args, **kwargs):
     print
@@ -73,28 +78,6 @@ def run_subprocess(*args, **kwargs):
         print p.stdout
 
     return p
-
-def create_fjr(config, usage, outfile='report.xml'):
-
-    report = FwkJobReport()
-    report.status = 0
-    checksums, events = calculate_alder32(config)
-
-    for local, remote in config['output files']:
-
-        file = report.newFile()
-        file.state = 'closed'
-        file['PFN'] = local
-        file['Checksum'] = checksums.get(os.path.basename(remote), None)
-        file['TotalEvents'] = events.get(os.path.basename(remote), 0)
-
-    jobcpu = {'TotalJobCPU': usage.ru_stime}
-    performance = PerformanceReport()
-    performance.addSummary("Timing", **jobcpu)
-    report.performance = performance
-
-    report.write(outfile)
-
 
 def calculate_alder32(config):
     """Try to calculate checksums for output files.
@@ -452,7 +435,7 @@ def edit_process_source(pset, config):
         print frag
         fp.write(frag)
 
-def extract_info(config, data, report_filename):
+def parse_fwk_report(config, data, report_filename):
     """Extract job data from a framework report.
 
     Analyze the CMSSW job framework report to get the CMSSW exit code,
@@ -465,36 +448,34 @@ def extract_info(config, data, report_filename):
     written = 0
     eventsPerRun = 0
 
-    with open(report_filename) as f:
-        for report in readJobReport(f):
-            for error in report.errors:
-                code = error.get('ExitStatus', exit_code)
-                if exit_code == 0:
-                    exit_code = code
+    report = Report("cmsrun")
+    report.parse(report_filename)
 
-            for file in report.skippedFiles:
-                filename = file['Lfn']
-                filename = config['file map'].get(filename, filename)
-                skipped.append(file['Lfn'])
+    exit_code = report.getExitCode()
 
-            for file in report.files:
-                written += int(file['TotalEvents'])
+    for file in report.getAllSkippedFiles():
+        filename = file['Lfn']
+        filename = config['file map'].get(filename, filename)
+        skipped.append(file['Lfn'])
 
-            for file in report.inputFiles:
-                filename = file['LFN'] if len(file['LFN']) > 0 else file['PFN']
-                filename = config['file map'].get(filename, filename)
-                file_lumis = []
-                try:
-                    for run, ls in file['Runs'].items():
-                        for lumi in ls:
-                            file_lumis.append((run, lumi))
-                except AttributeError:
-                    print 'Detected file-based job.'
-                infos[filename] = (int(file['EventsRead']), file_lumis)
-                eventsPerRun += infos[filename][0]
+    for file in report.getAllFiles():
+        written += int(file['events'])
 
-            timing = report.performance.summaries['Timing']
-            cputime = timing.get('TotalEventCPU', timing.get('TotalJobCPU', 0))
+    for file in report.getAllInputFiles():
+        filename = file['lfn'] if len(file['lfn']) > 0 else file['pfn']
+        filename = config['file map'].get(filename, filename)
+        file_lumis = []
+        try:
+            for run in file['runs'].items():
+                for lumi in run.lumis:
+                    file_lumis.append((run.run, lumi))
+        except AttributeError:
+            print 'Detected file-based job.'
+        infos[filename] = (int(file['events']), file_lumis)
+        eventsPerRun += infos[filename][0]
+
+    serialized = report.__to_json__(None)
+    cputime = float(serialized['steps']['cmsrun']['performance']['cpu'].get('TotalJobCPU', '0'))
 
     data['files']['info'] = infos
     data['files']['skipped'] = skipped
@@ -504,8 +485,6 @@ def extract_info(config, data, report_filename):
     # events
     data['cpu time'] = cputime
     data['events per run'] = eventsPerRun
-
-    return cputime
 
 def extract_time(filename):
     """Load file contents as integer timestamp.
@@ -623,7 +602,7 @@ parameters = {
             'WNHostName': os.environ.get('HOSTNAME', '')
             }
 
-apmonSend(taskid, monitorid, parameters)
+apmonSend(taskid, monitorid, parameters, logging, monalisa)
 apmonFree()
 
 print
@@ -663,13 +642,14 @@ if p.returncode != 0:
     print ">>> Executable return code != 0.  Check for errors!"
 
 if cmsRun:
-    apmonSend(taskid, monitorid, {'ExeEnd': 'cmsRun'})
-else:
-    create_fjr(config, usage)
+    apmonSend(taskid, monitorid, {'ExeEnd': 'cmsRun'}, logging, monalisa)
 
-cputime = 0
-with check_execution(data, 190):
-    cputime = extract_info(config, data, 'report.xml')
+    with check_execution(data, 190):
+        parse_fwk_report(config, data, 'report.xml')
+else:
+    data['files']['info'] = dict((f, [0, []]) for f in config['file map'].values())
+    data['cpu time'] = usage.ru_stime
+    data['cmssw exit code'] = data['exe exit code']
 
 with check_execution(data, 191):
     data['task timing info'][:2] = [extract_time('t_wrapper_start'), extract_time('t_wrapper_ready')]
@@ -687,6 +667,9 @@ if cmsRun:
 data['task timing info'].append(now)
 
 if len(epilogue) > 0:
+    # Make data collected so far available to the epilogue
+    with open('report.json', 'w') as f:
+        json.dump(data, f, indent=2)
     print ">>> epilogue:"
     with check_execution(data, 199):
         p = run_subprocess(epilogue,env=env)
@@ -698,6 +681,8 @@ if len(epilogue) > 0:
         # a non-zero return code.
         if p.returncode != 0:
             raise subprocess.CalledProcessError
+    with open('report.json', 'r') as f:
+        data = json.load(f)
 
 data['task timing info'].append(int(datetime.now().strftime('%s')))
 
@@ -744,6 +729,7 @@ for filename in 'executable.log report.xml'.split():
                 zipf.writelines(f)
                 zipf.close()
 
+cputime = data['cpu time']
 total_time = data['task timing info'][-1] - data['task timing info'][0]
 exe_wc_time = data['task timing info'][-3] - data['task timing info'][3]
 job_exit_code = data['job exit code']
@@ -777,7 +763,7 @@ try:
 except:
     pass
 
-apmonSend(taskid, monitorid, parameters)
+apmonSend(taskid, monitorid, parameters, logging, monalisa)
 apmonFree()
 
 sys.exit(job_exit_code)

--- a/lobster/cmssw/data/wrapper.sh
+++ b/lobster/cmssw/data/wrapper.sh
@@ -36,7 +36,7 @@ export LOBSTER_LCG_CP LOBSTER_GFAL_COPY
 LOBSTER_PROXY_INFO=$(command -v grid-proxy-init)
 
 unset PARROT_HELPER
-export PYTHONPATH=/cvmfs/cms.cern.ch/crab/CRAB_2_10_5_patch1/python/:$PYTHONPATH
+export PYTHONPATH=python:$PYTHONPATH
 
 if [ -z "$LD_LIBRARY_PATH" ]; then
 	export LD_LIBRARY_PATH=lib

--- a/lobster/cmssw/dataset.py
+++ b/lobster/cmssw/dataset.py
@@ -4,7 +4,6 @@ import os
 import sys
 from lobster import util, fs
 
-sys.path.insert(0, '/cvmfs/cms.cern.ch/crab/CRAB_2_10_2_patch2/external/dbs3client')
 from dbs.apis.dbsClient import DbsApi
 from FWCore.PythonUtilities.LumiList import LumiList
 

--- a/lobster/cmssw/job.py
+++ b/lobster/cmssw/job.py
@@ -17,7 +17,6 @@ import jobit
 from dataset import MetaInterface
 
 from FWCore.PythonUtilities.LumiList import LumiList
-from ProdCommon.CMSConfigTools.ConfigAPI.CfgInterface import CfgInterface
 
 import work_queue as wq
 
@@ -254,13 +253,13 @@ class JobProvider(job.JobProvider):
                 sys.argv = ["pacify_varparsing.py"]
                 with open(util.findpath(self.basedirs, cms_config), 'r') as f:
                     source = imp.load_source('cms_config_source', cms_config, f)
-                    cfg_interface = CfgInterface(source.process)
-                    if hasattr(cfg_interface.data, 'GlobalTag') and hasattr(cfg_interface.data.GlobalTag.globaltag, 'value'):
-                        cfg['global tag'] = cfg_interface.data.GlobalTag.globaltag.value()
-                    for m in cfg_interface.data.outputModules:
-                        self.outputs[label].append(getattr(cfg_interface.data, m).fileName.value())
-                    if hasattr(cfg_interface.data, 'TFileService'):
-                        self.outputs[label].append(cfg_interface.data.TFileService.fileName.value())
+                    process = source.process
+                    if hasattr(process, 'GlobalTag') and hasattr(process.GlobalTag.globaltag, 'value'):
+                        cfg['global tag'] = process.GlobalTag.globaltag.value()
+                    for label, module in process.outputModules.items():
+                        self.outputs[label].append(module.fileName.value())
+                    if 'TFileService' in process.services:
+                        self.outputs[label].append(process.services['TFileService'].fileName.value())
                         self.__edm_outputs[label] = False
 
                     logger.info("workflow {0}: adding output file(s) '{1}'".format(label, ', '.join(self.outputs[label])))

--- a/lobster/cmssw/job.py
+++ b/lobster/cmssw/job.py
@@ -315,6 +315,17 @@ class JobProvider(job.JobProvider):
                       (self.parrot_lib, 'lib', None)
                       ]
 
+            # Files to make the job wrapper work without referencing WMCore
+            # from somewhere else
+            import WMCore
+            base = os.path.dirname(WMCore.__file__)
+            reqs = [
+                    "Services/Dashboard/DashboardAPI.pyc",
+                    "FwkJobReport"
+                    ]
+            for f in reqs:
+                inputs.append((os.path.join(base, f), os.path.join("python", "WMCore", f), True))
+
             if merge:
                 if not self.__edm_outputs[label]:
                     cmd = 'hadd'

--- a/lobster/cmssw/publish.py
+++ b/lobster/cmssw/publish.py
@@ -12,11 +12,10 @@ import logging
 
 from FWCore.PythonUtilities.LumiList import LumiList
 from RestClient.ErrorHandling.RestClientExceptions import HTTPError
-from ProdCommon.FwkJobRep.ReportParser import readJobReport
-from ProdCommon.FwkJobRep.SiteLocalConfig import SiteLocalConfig
-from ProdCommon.FwkJobRep.TrivialFileCatalog import readTFC
+from WMCore.FwkJobRep.ReportParser import readJobReport
+from WMCore.FwkJobRep.SiteLocalConfig import SiteLocalConfig
+from WMCore.FwkJobRep.TrivialFileCatalog import readTFC
 from ProdCommon.MCPayloads.WorkflowTools import createPSetHash
-sys.path.insert(0, '/cvmfs/cms.cern.ch/crab/CRAB_2_10_2_patch2/external/dbs3client')
 from dbs.apis.dbsClient import DbsApi
 
 from lobster import util

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     install_requires=[
         'argparse',
         'dbs',
+        'httplib2', # actually a WMCore dependency
         'jinja2',
         'nose',
         'pyyaml',

--- a/setup.py
+++ b/setup.py
@@ -21,12 +21,18 @@ setup(
     ]},
     install_requires=[
         'argparse',
+        'dbs',
         'jinja2',
         'nose',
         'pyyaml',
         'python-daemon',
         'python-dateutil',
-        'pytz'
+        'pytz',
+        'WMCore'
+    ],
+    dependency_links = [
+        'git+https://github.com/dmwm/DBS@DBS_3_2_114#egg=dbs-3.2.114',
+        'git+https://github.com/dmwm/WMCore@1.0.9.patch2#egg=WMCore-1.0.9.patch2'
     ],
     entry_points={
         'console_scripts': ['lobster = lobster.ui:boil']


### PR DESCRIPTION
Putting this out for preliminary preview.  This should remove all dependencies on CRAB2.  Done by rewriting essential parts of the framework job report parsing (which is now only done for `cmsRun` jobs), and saving all information to our report JSON.  The latter is the only file needed for publishing, merging, etc...

Testing is still ongoing. 