### PR TITLE
User fixes

### DIFF
--- a/examples/custom_command.sh
+++ b/examples/custom_command.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+echo arguments: $*
+
+optional=
+output=
+
+while getopts a:o: opt; do
+	case $opt in
+		a)
+			optional=$OPTARG
+			;;
+		o)
+			output=$OPTARG
+			;;
+		?)
+			exit 1
+			;;
+	esac
+done
+
+for i in $(seq $(($OPTIND-1))); do
+	shift
+done
+
+echo "output file:   $output"
+echo "optional file: $optional"
+echo "input files:   $*"
+
+if [ -n "$output" -a -n "$*" ]; then
+	echo ">>> producing output"
+	for i in $(seq 5); do
+		cat $* >> $output
+	done
+fi
+
+if [ -n "$optional" ]; then
+	echo ">>> content of $optional:"
+	cat $optional
+fi

--- a/examples/custom_command.txt
+++ b/examples/custom_command.txt
@@ -1,0 +1,1 @@
+This is a random optional input file.

--- a/examples/custom_command.yaml
+++ b/examples/custom_command.yaml
@@ -1,0 +1,66 @@
+id: <your id here>
+workdir: <your working directory here>
+## optional: to automatically update monitoring plots
+plotdir: <your plotting directory here>
+
+storage:
+    use work queue for inputs:  true  # default is false
+    use work queue for outputs: true  # default is false
+
+    input:
+      - file:///afs/crc.nd.edu/user/m/mwolf3/Public/lobster
+
+    output:
+      - file:///tmp/lobster_example
+
+## report jobs to the CMS dashboard (default is true)
+use dashboard: true
+
+## optional: if a job exits with a code in this list, the host it ran on will be blacklisted
+# bad exit codes: [1, 2]
+
+## optional: specify directories in CMSSW work area to omit from sandbox
+# sandbox blacklist: ['*DrawPlots*']
+
+# advanced:
+  ## start killing jobs with excessive runtimes after this many successful
+  ## jobs
+  # abort threshold: 10
+  ## define excessive runtime in multiples of the average runtime
+  # abort multiplier: 4
+  ## enables core dumps by overriding `ulimit` settings
+  # dump core: false
+  ## override automatic proxy renewal
+  # renew proxy: false
+  ## level of verbosity.  Everything is 1, only critical messages is 5, default 2
+  # log level: 0
+  ## how many jobs to create and keep in the queue
+  # payload: 400
+
+## task fields:
+##      required:
+##             label (string): label for this task
+##             outputs (list): output files to be collected
+##      must include one of the following:
+##              cmssw config (string): path to cmssw parameter set to call cmsRun on
+##              cmd (string): command to run
+##      optional:
+##              one of:
+##                      dataset (string): DBS dataset name of input files to run over
+##                      files (string): path to input files (wildcards accepted)
+##              one of:
+##                      events per job (int): number of events to process per job
+##                      lumis per job (int): lumis to process per job (default: 25)
+##              lumi mask (string): path to lumi mask to apply
+##              parameters (list of strings): parameters to pass to cmsRun
+##              extra inputs (list of strings): extra files needed to run the job
+##              publish label (string): label to include in the published dataset name
+##              output format (string): optional renaming of files, based on their basename and extension
+##                                      for example, "this_is_file_{id}_{base}.{ext}"
+
+tasks:
+  - label: something
+    cmd: "custom_command.sh -o foo.txt -a custom_command.txt"
+    extra inputs: [custom_command.txt]
+    output: [foo.txt]
+    files: inputs

--- a/lobster/cmssw/actions.py
+++ b/lobster/cmssw/actions.py
@@ -23,7 +23,7 @@ class Actions(object):
             logger.info('plots in {0} will be updated automatically'.format(config['plotdir']))
             if 'foremen logs' in config:
                 logger.info('foremen logs will be included from: {0}'.format(', '.join(config['foremen logs'])))
-            plotter = Plotter(config['filename'], config['plotdir'])
+            plotter = Plotter(config['workdir'], config['plotdir'])
 
             def plotf(q):
                 while q.get() not in ('stop', None):

--- a/lobster/cmssw/actions.py
+++ b/lobster/cmssw/actions.py
@@ -23,7 +23,7 @@ class Actions(object):
             logger.info('plots in {0} will be updated automatically'.format(config['plotdir']))
             if 'foremen logs' in config:
                 logger.info('foremen logs will be included from: {0}'.format(', '.join(config['foremen logs'])))
-            plotter = Plotter(config['workdir'], config['plotdir'])
+            plotter = Plotter(config, config['plotdir'])
 
             def plotf(q):
                 while q.get() not in ('stop', None):

--- a/lobster/cmssw/plotting.py
+++ b/lobster/cmssw/plotting.py
@@ -82,11 +82,8 @@ class Plotter(object):
     PLOT = 4
     PROF = 8
 
-    def __init__(self, workdir, outdir=None):
-        with open(os.path.join(workdir, 'lobster_config.yaml')) as f:
-            config = yaml.load(f)
-
-        self.__workdir = workdir
+    def __init__(self, config, outdir=None):
+        self.__workdir = config['workdir']
 
         util.verify(self.__workdir)
         self.__id = config['id']
@@ -982,5 +979,5 @@ def plot(args):
     logger.setLevel(logging.INFO)
     logger.addHandler(console)
 
-    p = Plotter(args.workdir, args.outdir)
+    p = Plotter(args.config, args.outdir)
     p.make_plots(args.xmin, args.xmax, args.foreman_list)

--- a/lobster/cmssw/plotting.py
+++ b/lobster/cmssw/plotting.py
@@ -82,14 +82,12 @@ class Plotter(object):
     PLOT = 4
     PROF = 8
 
-    def __init__(self, configfile, outdir=None, resume_workdir=False):
-        with open(configfile) as f:
+    def __init__(self, workdir, outdir=None):
+        with open(os.path.join(workdir, 'lobster_config.yaml')) as f:
             config = yaml.load(f)
 
-        if resume_workdir:
-            self.__workdir = os.path.dirname(configfile)
-        else:
-            self.__workdir = os.path.expandvars(os.path.expanduser(config["workdir"]))
+        self.__workdir = workdir
+
         util.verify(self.__workdir)
         self.__id = config['id']
 
@@ -984,5 +982,5 @@ def plot(args):
     logger.setLevel(logging.INFO)
     logger.addHandler(console)
 
-    p = Plotter(args.configfile, args.outdir, args.resume)
+    p = Plotter(args.workdir, args.outdir)
     p.make_plots(args.xmin, args.xmax, args.foreman_list)

--- a/lobster/cmssw/publish.py
+++ b/lobster/cmssw/publish.py
@@ -273,10 +273,7 @@ class BlockDump(object):
         self.data[key] = value
 
 def publish(args):
-    with open(args.configfile) as f:
-        config = yaml.load(f)
-
-    config = apply_matching(config)
+    config = apply_matching(args.config)
 
     if len(args.datasets) == 0:
         args.datasets = [task['label'] for task in config.get('tasks', [])]

--- a/lobster/core.py
+++ b/lobster/core.py
@@ -33,15 +33,11 @@ class ShortPathFormatter(logging.Formatter):
 
 def kill(args):
     logger.info("setting flag to quit at the next checkpoint")
-    with open(args.configfile) as configfile:
-        config = yaml.load(configfile)
-
-    workdir = config['workdir']
+    workdir = args.config['workdir']
     util.register_checkpoint(workdir, 'KILLED', 'PENDING')
 
 def run(args):
-    with open(args.configfile) as configfile:
-        config = yaml.load(configfile)
+    config = args.config
 
     workdir = config['workdir']
     if not os.path.exists(workdir):
@@ -105,10 +101,6 @@ def run(args):
             console.setLevel(level)
             console.setFormatter(ShortPathFormatter("%(asctime)s [%(levelname)5s] - %(pathname)-40s %(lineno)4d: %(message)s"))
             logger.addHandler(console)
-
-        config['base directory'] = args.configdir
-        config['base configuration'] = args.configfile
-        config['startup directory'] = args.startdir
 
         t = threading.Thread(target=sprint, args=(config, workdir, cmsjob))
         t.start()

--- a/lobster/core.py
+++ b/lobster/core.py
@@ -106,9 +106,9 @@ def run(args):
             console.setFormatter(ShortPathFormatter("%(asctime)s [%(levelname)5s] - %(pathname)-40s %(lineno)4d: %(message)s"))
             logger.addHandler(console)
 
-        config['configdir'] = args.configdir
-        config['filename'] = args.configfile
-        config['startdir'] = args.startdir
+        config['base directory'] = args.configdir
+        config['base configuration'] = args.configfile
+        config['startup directory'] = args.startdir
 
         t = threading.Thread(target=sprint, args=(config, workdir, cmsjob))
         t.start()

--- a/lobster/job.py
+++ b/lobster/job.py
@@ -128,6 +128,10 @@ class JobProvider(object):
             target = os.path.join(self.workdir, label, os.path.basename(fn))
 
             if not os.path.exists(target) or overwrite:
+                if not os.path.exists(os.path.dirname(target)):
+                    os.makedirs(os.path.dirname(target))
+
+                logger.debug("copying '{0}' to '{1}'".format(source, target))
                 if os.path.isfile(source):
                     shutil.copy(source, target)
                 elif os.path.isdir(source):

--- a/lobster/ui.py
+++ b/lobster/ui.py
@@ -82,8 +82,8 @@ def boil():
 
     if configfile == args.checkpoint:
         # This is the original configuration file!
-        args.config['base directory'] = os.path.dirname(configfile)
-        args.config['base configuration'] = configfile
-        args.config['startup directory'] = os.getcwd()
+        args.config['base directory'] = os.path.abspath(os.path.dirname(configfile))
+        args.config['base configuration'] = os.path.abspath(configfile)
+        args.config['startup directory'] = os.path.abspath(os.getcwd())
 
     args.func(args)

--- a/lobster/ui.py
+++ b/lobster/ui.py
@@ -6,6 +6,7 @@ from lobster.cmssw.plotting import plot
 from lobster.cmssw.publish import publish
 from lobster.core import kill, run
 from lobster.validate import validate
+from lobster import util
 
 def boil():
     parser = ArgumentParser(description='A job submission tool for CMS')

--- a/lobster/validate.py
+++ b/lobster/validate.py
@@ -7,8 +7,7 @@ from lobster import cmssw, fs, se
 from lobster.job import apply_matching
 
 def validate(args):
-    with open(args.configfile) as configfile:
-        config = yaml.load(configfile)
+    config = args.config
 
     logger = multiprocessing.get_logger()
 


### PR DESCRIPTION
Just putting this out there.  Validation is broken if the user does not specify output files in the configuration.  This will save an expanded configuration to the working directory, containing output files and global tags.

For complete user-friendliness, the following still have to be addressed, at least partially:

- [ ] #28 
- [x] Fixes #84 
- [x] Fixes #77