### PR TITLE
Handler shuffle

### DIFF
--- a/lobster/__init__.py
+++ b/lobster/__init__.py
@@ -1,1 +1,1 @@
-
+import cmssw

--- a/lobster/cmssw/__init__.py
+++ b/lobster/cmssw/__init__.py
@@ -1,5 +1,4 @@
 from actions import Actions
+from handler import TaskHandler
+from workflow import Workflow
 from job import JobProvider
-from jobit import JobitStore
-from plotting import plot
-from publish import publish

--- a/lobster/cmssw/data/job.py
+++ b/lobster/cmssw/data/job.py
@@ -602,7 +602,7 @@ args = config['arguments']
 prologue = config.get('prologue', [])
 epilogue = config.get('epilogue', [])
 
-if len(prologue) > 0:
+if prologue and len(prologue) > 0:
     print ">>> prologue:"
     with check_execution(data, 180):
         p = run_subprocess(prologue,env=env)
@@ -693,7 +693,7 @@ if cmsRun:
 
 data['task timing info'].append(now)
 
-if len(epilogue) > 0:
+if epilogue and len(epilogue) > 0:
     # Make data collected so far available to the epilogue
     with open('report.json', 'w') as f:
         json.dump(data, f, indent=2)

--- a/lobster/cmssw/handler.py
+++ b/lobster/cmssw/handler.py
@@ -51,6 +51,10 @@ class TaskHandler(object):
         return self._file_based
 
     @property
+    def input_files(self):
+        return list(set([filename for (id, filename) in self._files if filename]))
+
+    @property
     def jobit_source(self):
         return 'jobs' if self._merge else 'jobits_' + self._dataset
 
@@ -114,7 +118,7 @@ class TaskHandler(object):
         if se.transfer_outputs():
             outputs += [(se.local(rf), os.path.basename(lf)) for lf, rf in self._outputs]
 
-        parameters['mask']['files'] = list(set([filename for (id, filename) in self._files if filename]))
+        parameters['mask']['files'] = self.input_files
         parameters['output files'] = self._outputs
         if not self._file_based and not self._merge:
             ls = LumiList(lumis=set([(run, lumi) for (id, file, run, lumi) in self._jobits]))

--- a/lobster/cmssw/handler.py
+++ b/lobster/cmssw/handler.py
@@ -42,14 +42,6 @@ class TaskHandler(object):
     def jobdir(self):
         return self._jobdir
 
-    @jobdir.setter
-    def jobdir(self, dir):
-        self._jobdir = dir
-
-    @property
-    def file_based(self):
-        return self._file_based
-
     @property
     def input_files(self):
         return list(set([filename for (id, filename) in self._files if filename]))

--- a/lobster/cmssw/handler.py
+++ b/lobster/cmssw/handler.py
@@ -1,0 +1,121 @@
+from lobster.cmssw import jobit
+
+from FWCore.PythonUtilities.LumiList import LumiList
+
+class TaskHandler(object):
+    """
+    Handles mapping of lumi sections to files etc.
+    """
+
+    def __init__(
+            self, id, dataset, files, lumis, outputs, jobdir,
+            cmssw_job=True, empty_source=False, merge=False, local=False):
+        self._id = id
+        self._dataset = dataset
+        self._files = [(id, file) for id, file in files]
+        self._file_based = any([run < 0 or lumi < 0 for (id, file, run, lumi) in lumis])
+        self._jobits = lumis
+        self._jobdir = jobdir
+        self._outputs = outputs
+        self._merge = merge
+        self._cmssw_job = cmssw_job
+        self._empty_source = empty_source
+        self._local = local
+
+    @property
+    def cmssw_job(self):
+        return self._cmssw_job
+
+    @property
+    def dataset(self):
+        return self._dataset
+
+    @property
+    def outputs(self):
+        return self._outputs
+
+    @property
+    def id(self):
+        return self._id
+
+    @property
+    def jobdir(self):
+        return self._jobdir
+
+    @jobdir.setter
+    def jobdir(self, dir):
+        self._jobdir = dir
+
+    @property
+    def file_based(self):
+        return self._file_based
+
+    @property
+    def jobit_source(self):
+        return 'jobs' if self._merge else 'jobits_' + self._dataset
+
+    @property
+    def merge(self):
+        return self._merge
+
+    def get_jobit_info(self, failed, files_info, files_skipped, events_written):
+        events_read = 0
+        file_update = []
+        jobit_update = []
+
+        jobits_processed = len(self._jobits)
+
+        for (id, file) in self._files:
+            file_jobits = [tpl for tpl in self._jobits if tpl[1] == id]
+
+            skipped = False
+            read = 0
+            if self._cmssw_job:
+                if not self._empty_source:
+                    skipped = file in files_skipped or file not in files_info
+                    read = 0 if failed or skipped else files_info[file][0]
+
+            events_read += read
+
+            if failed:
+                jobits_processed = 0
+            else:
+                if skipped:
+                    for (lumi_id, lumi_file, r, l) in file_jobits:
+                        jobit_update.append((jobit.FAILED, lumi_id))
+                        jobits_processed -= 1
+                elif not self._file_based:
+                    file_lumis = set(map(tuple, files_info[file][1]))
+                    for (lumi_id, lumi_file, r, l) in file_jobits:
+                        if (r, l) not in file_lumis:
+                            jobit_update.append((jobit.FAILED, lumi_id))
+                            jobits_processed -= 1
+
+            file_update.append((read, 1 if skipped else 0, id))
+
+        if failed:
+            events_written = 0
+            status = jobit.FAILED
+        else:
+            status = jobit.SUCCESSFUL
+
+        if self._merge:
+            file_update = []
+            # FIXME not correct
+            jobits_missed = 0
+
+        return jobits_processed, events_read, events_written, status, \
+                file_update, jobit_update
+
+    def adjust(self, parameters, inputs, outputs, se):
+        local = self._local or self._merge
+        if local and se.transfer_inputs():
+            inputs += [(se.local(f), os.path.basename(f), False) for id, f in self._files if f]
+        if se.transfer_outputs():
+            outputs += [(se.local(rf), os.path.basename(lf)) for lf, rf in self._outputs]
+
+        parameters['mask']['files'] = list(set([filename for (id, filename) in self._files if filename]))
+        parameters['output files'] = self._outputs
+        if not self._file_based and not self._merge:
+            ls = LumiList(lumis=set([(run, lumi) for (id, file, run, lumi) in self._jobits]))
+            parameters['mask']['lumis'] = ls.getCompactList()

--- a/lobster/cmssw/job.py
+++ b/lobster/cmssw/job.py
@@ -126,8 +126,8 @@ class JobProvider(job.JobProvider):
             if wflow.pset:
                  shutil.copy(util.findpath(self.basedirs, wflow.pset), os.path.join(wflow.workdir, os.path.basename(wflow.pset)))
 
-            if wflow.pset and not wflow.outputs:
-                wflow.outputs = []
+            if wflow.pset and not wflow._outputs:
+                wflow._outputs = []
                 # Save determined outputs to the configuration in the
                 # working directory.
                 update_config = True
@@ -139,15 +139,15 @@ class JobProvider(job.JobProvider):
                     if hasattr(process, 'GlobalTag') and hasattr(process.GlobalTag.globaltag, 'value'):
                         cfg['global tag'] = process.GlobalTag.globaltag.value()
                     for label, module in process.outputModules.items():
-                        wflow.outputs.append(module.fileName.value())
+                        wflow._outputs.append(module.fileName.value())
                     if 'TFileService' in process.services:
-                        wflow.outputs.append(process.services['TFileService'].fileName.value())
+                        wflow._outputs.append(process.services['TFileService'].fileName.value())
                         wflow.edm_output = False
 
-                    self.config['tasks'][label]['edm output'] = wflow.edm_output
-                    self.config['tasks'][label]['outputs'] = wflow.outputs
+                    wflow.config['edm output'] = wflow.edm_output
+                    wflow.config['outputs'] = wflow._outputs
 
-                    logger.info("workflow {0}: adding output file(s) '{1}'".format(label, ', '.join(wflow.outputs)))
+                    logger.info("workflow {0}: adding output file(s) '{1}'".format(label, ', '.join(wflow._outputs)))
 
             if not util.checkpoint(self.workdir, label):
                 if wflow.pset:

--- a/lobster/cmssw/job.py
+++ b/lobster/cmssw/job.py
@@ -375,7 +375,7 @@ class JobProvider(job.JobProvider):
                 cleanup += [lf for rf, lf in handler.outputs]
             else:
                 if handler.merge and self.config.get('delete merged', True):
-                    files, _ = handler.get_job_info()
+                    files = handler.input_files
                     cleanup += files
                 self.move_jobdir(handler.id, handler.dataset, 'successful')
 

--- a/lobster/cmssw/job.py
+++ b/lobster/cmssw/job.py
@@ -221,15 +221,11 @@ class JobProvider(job.JobProvider):
 
                 for job, _, _, _ in lumis:
                     report = self.get_report(label, job)
-                    base, ext = os.path.splitext(wflow.outputs[0])
-                    input = os.path.join(label, wflow.outputformats.format(base=base, ext=ext[1:], id=job))
+                    _, infile = list(wflow.outputs(job))[0]
 
                     if os.path.isfile(report):
                         inreports.append(report)
-                        infiles.append((job, input))
-                        # FIXME we can also read files locally
-                        # if not self.__chirp and not self.__xrootd:
-                            # inputs.append((input, os.path.basename(input), False))
+                        infiles.append((job, infile))
                     else:
                         missing.append(job)
 

--- a/lobster/cmssw/workflow.py
+++ b/lobster/cmssw/workflow.py
@@ -34,7 +34,7 @@ class Workflow(object):
             inputs.extend((r, "_".join(os.path.normpath(r).split(os.sep)[-3:]), False) for r in reports)
 
             if self.edm_output:
-                args = ['output=' + self.outputs[0]]
+                args = ['output=' + self._outputs[0]]
                 pset = os.path.join(os.path.dirname(__file__), 'data', 'merge_cfg.py')
                 params['append inputs to args'] = True
             else:

--- a/lobster/cmssw/workflow.py
+++ b/lobster/cmssw/workflow.py
@@ -1,0 +1,65 @@
+import os
+
+class Workflow(object):
+    def __init__(self, workdir, config):
+        self.config = config
+        self.label = config['label']
+        self.workdir = os.path.join(workdir, self.label)
+
+        self.cmd = config.get('cmd', 'cmsRun')
+        self.extra_inputs = config.get('extra inputs', [])
+        self.args = config.get('parameters', [])
+        self._outputs = config.get('outputs')
+        self.outputformat = config.get("output format", "{base}_{id}.{ext}")
+
+        self.events_per_task = config.get('events per job', -1)
+        self.pset = config.get('cmssw config')
+        self.local = config.get('local', 'files' in config)
+        self.edm_output = config.get('edm output', True)
+
+    def outputs(self, id):
+        for fn in self._outputs:
+            base, ext = os.path.splitext(fn)
+            outfn = self.outputformat.format(base=base, ext=ext[1:], id=id)
+            yield fn, os.path.join(self.label, outfn)
+
+    def adjust(self, params, taskdir, inputs, outputs, merge, reports=None, unique=None):
+        cmd = self.cmd
+        args = self.args
+        pset = self.pset
+
+        if merge:
+            inputs.append((os.path.join(os.path.dirname(__file__), 'data', 'merge_reports.py'), 'merge_reports.py', True))
+            inputs.append((os.path.join(os.path.dirname(__file__), 'data', 'job.py'), 'job.py', True))
+            inputs.extend((r, "_".join(os.path.normpath(r).split(os.sep)[-3:]), False) for r in reports)
+
+            if self.edm_output:
+                args = ['output=' + self.outputs[0]]
+                pset = os.path.join(os.path.dirname(__file__), 'data', 'merge_cfg.py')
+                params['append inputs to args'] = True
+            else:
+                cmd = 'hadd'
+                args = ['-f', self.outputs[0]]
+                pset = None
+
+            params['prologue'] = None
+            params['epilogue'] = ['python', 'merge_reports.py', 'report.json'] \
+                    + ["_".join(os.path.normpath(r).split(os.sep)[-3:]) for r in reports]
+        else:
+            inputs.extend((i, os.path.basename(i), True) for i in self.extra_inputs)
+
+            if unique:
+                args.append(unique)
+
+            if pset:
+                pset = os.path.join(self.workdir, pset)
+
+        if pset:
+            inputs.append((pset, os.path.basename(pset), True))
+            outputs.append((os.path.join(taskdir, 'report.xml.gz'), 'report.xml.gz'))
+
+            params['pset'] = os.path.basename(pset)
+
+        params['executable'] = cmd
+        params['arguments'] = args
+        params['mask']['events'] = self.events_per_task

--- a/lobster/cmssw/workflow.py
+++ b/lobster/cmssw/workflow.py
@@ -1,5 +1,7 @@
 import os
 
+from lobster import fs
+
 class Workflow(object):
     def __init__(self, workdir, config):
         self.config = config
@@ -46,6 +48,20 @@ class Workflow(object):
         files = map(copy_file, self.config['extra inputs'])
         self.config['extra inputs'] = files
         self.extra_inputs = files
+
+    def create(self):
+        # Working directory for workflow
+        # TODO Should we really check if this already exists?  IMO that
+        # constitutes an error, since we really should create the workflow!
+        if not os.path.exists(self.workdir):
+            os.makedirs(self.workdir)
+        # Create the stageout directory
+        if not fs.exists(self.label):
+            fs.makedirs(self.label)
+        else:
+            if len(list(fs.ls(self.label))) > 0:
+                msg = 'stageout directory is not empty: {0}'
+                raise IOError(msg.format(fs.__getattr__('lfn2pfn')(self.label)))
 
     def outputs(self, id):
         for fn in self._outputs:

--- a/lobster/job.py
+++ b/lobster/job.py
@@ -13,7 +13,7 @@ import yaml
 
 from functools import partial
 from hashlib import sha1
-from lobster import fs, se, util
+from lobster import se, util
 from lobster.cmssw import Workflow
 
 logger = multiprocessing.get_logger()
@@ -79,20 +79,11 @@ class JobProvider(object):
             wflow = Workflow(self.workdir, cfg)
             wflow.copy_inputs(self.basedirs)
             self.workflows[wflow.label] = wflow
-
-            taskdir = os.path.join(self.workdir, wflow.label)
             if create:
-                if not os.path.exists(taskdir):
-                    os.makedirs(taskdir)
-                # create the stageout directory
-                if not fs.exists(wflow.label):
-                    fs.makedirs(wflow.label)
-                else:
-                    if len(list(fs.ls(wflow.label))) > 0:
-                        msg = 'stageout directory is not empty: {0}'
-                        raise IOError(msg.format(fs.__getattr__('lfn2pfn')(wflow.label)))
+                wflow.create()
 
-                self.save_configuration()
+        if create:
+            self.save_configuration()
 
         for p in (self.parrot_bin, self.parrot_lib):
             if not os.path.exists(p):


### PR DESCRIPTION
Meant to eventually fix #67. Our current structure with tons of `if` statements when dealing with tasks is not really sustainable, and there's very little overview of which options can actually be passed for a workflow.

This PR should simplify how we handle task creation (and returning) by

* introducing a `Workflow` class for workflow-wide settings (which are still referred to as `task` in our configuration)
* moving the `JobHandler` to separate file

The `obtain` method of the `JobSource` should read as follows:

1. Get a bunch of stuff from the database
2. Create a skeleton of parameters we want to send along with the task
3. Have the `Workflow` apply workflow-wide settings
4. Have the `TaskHandler` (formerly known as `JobHandler`) apply task-specific settings
5. Send it off!

There are still some more code-rearrangements to come…