### PR TITLE
Switch to retrying

### DIFF
--- a/lobster/cmssw/job.py
+++ b/lobster/cmssw/job.py
@@ -171,8 +171,8 @@ class JobProvider(job.JobProvider):
         return os.path.join(self.workdir, label, 'successful', util.id2dir(job), 'report.json')
 
     def obtain(self, num=1):
-        jobinfos = self.retry(self.__store.pop_unmerged_jobs, (self.config.get('merge size', -1), 10), {}) \
-                + self.retry(self.__store.pop_jobits, (num,), {})
+        jobinfos = self.__store.pop_unmerged_jobs(self.config.get('merge size', -1), 10) \
+                + self.__store.pop_jobits(num)
         if not jobinfos or len(jobinfos) == 0:
             return None
 
@@ -228,7 +228,7 @@ class JobProvider(job.JobProvider):
                 if len(missing) > 0:
                     template = "the following have been marked as failed because their output could not be found: {0}"
                     logger.warning(template.format(", ".join(map(str, missing))))
-                    self.retry(self.__store.update_missing, (missing,), {})
+                    self.__store.update_missing(missing)
 
                 if len(infiles) <= 1:
                     # FIXME report these back to the database and then skip
@@ -396,7 +396,7 @@ class JobProvider(job.JobProvider):
                 logger.error("error removing {0}:\n{1}".format(task.tag, e))
 
         if len(jobs) > 0:
-            self.retry(self.__store.update_jobits, (jobs,), {})
+            self.__store.update_jobits(jobs)
 
     def terminate(self):
         for id in self.__store.running_jobs():

--- a/lobster/cmssw/jobit.py
+++ b/lobster/cmssw/jobit.py
@@ -3,6 +3,7 @@ import logging
 import math
 import os
 import random
+from retrying import retry
 import sqlite3
 import uuid
 
@@ -234,6 +235,7 @@ class JobitStore:
 
         self.db.commit()
 
+    @retry(stop_max_attempt_number=10)
     def pop_jobits(self, num=1):
         """
         Create a predetermined number of jobs.  The task these are
@@ -409,6 +411,7 @@ class JobitStore:
 
         return ids
 
+    @retry(stop_max_attempt_number=10)
     def update_jobits(self, jobinfos):
         job_updates = []
 
@@ -559,6 +562,7 @@ class JobitStore:
             from datasets""")
         return ["label events read written jobits unmasked done paused percent".split()] + list(cursor)
 
+    @retry(stop_max_attempt_number=10)
     def pop_unmerged_jobs(self, bytes, num=1):
         """Create merging jobs.
 
@@ -742,6 +746,7 @@ class JobitStore:
 
         self.db.commit()
 
+    @retry(stop_max_attempt_number=10)
     def update_missing(self, jobs):
         for job, dataset in self.db.execute("""select jobs.id,
             datasets.label

--- a/lobster/cmssw/jobit.py
+++ b/lobster/cmssw/jobit.py
@@ -235,7 +235,6 @@ class JobitStore:
 
         self.db.commit()
 
-    @retry(stop_max_attempt_number=10)
     def pop_jobits(self, num=1):
         """
         Create a predetermined number of jobs.  The task these are
@@ -275,6 +274,7 @@ class JobitStore:
                 tasks.extend(self.__pop_jobits(size, dataset, dataset_id, empty_source))
         return tasks
 
+    @retry(stop_max_attempt_number=10)
     def __pop_jobits(self, size, dataset, dataset_id, empty_source):
         """Internal method to create jobs from a dataset
         """

--- a/lobster/cmssw/jobit.py
+++ b/lobster/cmssw/jobit.py
@@ -406,9 +406,6 @@ class JobitStore:
                 db.execute("update jobits_{0} set status=4 where status=1".format(label))
                 db.execute("update jobits_{0} set status=2 where status=7".format(label))
                 self.update_dataset_stats(label)
-
-        db.commit()
-
         return ids
 
     @retry(stop_max_attempt_number=10)

--- a/lobster/job.py
+++ b/lobster/job.py
@@ -127,17 +127,3 @@ class JobProvider(object):
 
     def work_left(self):
         raise NotImplementedError
-
-    def retry(self, fct, args, kwargs, attempts=10):
-        while attempts > 0:
-            attempts -= 1
-
-            try:
-                return fct(*args, **kwargs)
-            except sqlite3.OperationalError:
-                logger.critical("failed to perform SQL operation.  {0} attempts remaining.".format(attempts))
-                if attempts <= 0:
-                    raise
-                time.sleep(1)
-
-

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         'python-daemon',
         'python-dateutil',
         'pytz',
+        'retrying',
         'WMCore'
     ],
     dependency_links = [


### PR DESCRIPTION
Remove homebrewed function, apply `retrying` in a save way.  Also fixes #213, as I checked the code, and `commit` is only used before functions return (no context manager used in most cases.)