### PR TITLE
Allow to specify memory requirements per task.

### DIFF
--- a/lobster/commands/process.py
+++ b/lobster/commands/process.py
@@ -245,16 +245,15 @@ def sprint(config, workdir, cmstask):
                 break
 
             hunger -= len(tasks)
-            for runtime, cores, cmd, id, inputs, outputs in tasks:
+            for runtime, memory, cores, cmd, id, inputs, outputs in tasks:
                 task = wq.Task(cmd)
                 task.specify_tag(id)
                 task.specify_cores(cores)
                 task.specify_max_retries(wq_max_retries)
                 if runtime:
                     task.specify_running_time(runtime * 10**6)
-                # temporary work-around?
-                # task.specify_memory(1000)
-                # task.specify_disk(4000)
+                if memory:
+                    task.specify_memory(memory)
 
                 for (local, remote, cache) in inputs:
                     if os.path.isfile(local):

--- a/lobster/core/source.py
+++ b/lobster/core/source.py
@@ -360,7 +360,7 @@ class TaskProvider(object):
 
             cmd = 'sh wrapper.sh python task.py parameters.json'
 
-            tasks.append((wflow.runtime, 1 if merge else wflow.cores, cmd, id, inputs, outputs))
+            tasks.append((wflow.runtime, wflow.memory, 1 if merge else wflow.cores, cmd, id, inputs, outputs))
 
             self.__taskhandlers[id] = handler
 

--- a/lobster/core/workflow.py
+++ b/lobster/core/workflow.py
@@ -18,6 +18,7 @@ class Workflow(object):
 
         self.cores = config.get('cores per task', 1)
         self._runtime = config.get('task runtime')
+        self.memory = config.get('task memory')
         self.mergesize = self.__check_merge(config.get('merge size', -1))
 
         if 'sandbox' in config:


### PR DESCRIPTION
Use the setting `task memory` on a per workflow basis to do so.
Fixes #255, may need minor adjustment for merge tasks.