### PR TITLE
Clarify which class errors are emanating from. Fixes #289.

### DIFF
--- a/lobster/util.py
+++ b/lobster/util.py
@@ -32,7 +32,11 @@ class PartiallyMutable(type):
         type.__init__(self, name, bases, attrs)
 
     def __call__(cls, *args, **kwargs):
-        res = type.__call__(cls, *args, **kwargs)
+        try:
+            res = type.__call__(cls, *args, **kwargs)
+        except Exception as e:
+            import sys
+            raise type(e), type(e)('{0!s}: {1}'.format(cls, e.message)), sys.exc_info()[2]
         return res
 
     @classmethod


### PR DESCRIPTION
This might not be quite the right message wording/formatting, but I think this is the right direction. We want to include what class we're dealing with in the error message while preserving the stack trace. Instead of getting:
```
Traceback (most recent call last):
  File "/afs/crc.nd.edu/user/a/awoodard/.lobster/bin/lobster", line 9, in <module>
    load_entry_point('Lobster==1.5', 'console_scripts', 'lobster')()
  File "/afs/crc.nd.edu/user/a/awoodard/lobster/lobster/ui.py", line 92, in boil
    cfg = imp.load_source('userconfig', configfile).config
  File "configs/v15_23d.py", line 28, in <module>
    files='ttH/',
  File "/afs/crc.nd.edu/user/a/awoodard/lobster/lobster/util.py", line 36, in __call__
    res = type.__call__(cls, *args, **kwargs)
TypeError: __init__() got an unexpected keyword argument 'files'
```
This PR introduces this:
```
Traceback (most recent call last):
  File "/afs/crc.nd.edu/user/a/awoodard/.lobster/bin/lobster", line 9, in <module>
    load_entry_point('Lobster==1.5', 'console_scripts', 'lobster')()
  File "/afs/crc.nd.edu/user/a/awoodard/lobster/lobster/ui.py", line 92, in boil
    cfg = imp.load_source('userconfig', configfile).config
  File "configs/v15_23d.py", line 28, in <module>
    files='ttH/',
  File "/afs/crc.nd.edu/user/a/awoodard/lobster/lobster/util.py", line 36, in __call__
    res = type.__call__(cls, *args, **kwargs)
TypeError: <class 'lobster.cmssw.dataset.Dataset'>: __init__() got an unexpected keyword argument 'files'
```