### PR TITLE
Add ca_info to DbsApi call 

### DIFF
--- a/lobster/cmssw/dataset.py
+++ b/lobster/cmssw/dataset.py
@@ -37,6 +37,7 @@ class Cache(object):
     def __del__(self):
         shutil.rmtree(self.cache)
 
+
 class Dataset(Configurable):
     """
     Specification for processing a dataset stored in DBS.
@@ -107,8 +108,10 @@ class Dataset(Configurable):
 
     def query_database(self, dataset, instance, mask, file_based):
         if instance not in self.__apis:
+            # FIXME Where should we pull CAINFO from?
+            ca_info = os.environ['GIT_SSL_CAINFO']
             dbs_url = 'https://cmsweb.cern.ch/dbs/prod/{0}/DBSReader'.format(instance)
-            self.__apis[instance] = DASWrapper(dbs_url)
+            self.__apis[instance] = DASWrapper(dbs_url, ca_info=ca_info)
 
         result = DatasetInfo()
 

--- a/lobster/cmssw/dataset.py
+++ b/lobster/cmssw/dataset.py
@@ -6,7 +6,7 @@ from retrying import retry
 import shutil
 import tempfile
 
-from lobster.core.dataset import FileInfo, DatasetInfo
+from lobster.core.dataset import DatasetInfo
 from lobster.util import Configurable
 
 from dbs.apis.dbsClient import DbsApi
@@ -124,7 +124,6 @@ class Dataset(Configurable):
             result.files[fn].events = info['event_count']
             result.files[fn].size = info['file_size']
 
-        files = set()
         if file_based:
             for info in self.__apis[instance].listFiles(dataset=dataset):
                 fn = info['logical_file_name']


### PR DESCRIPTION
I was overcomplicating things before-- turns out we can just use the usual methods to obtain the proxy for the DbsApi.