### PR TITLE
Fix unique arguments

### DIFF
--- a/lobster/core/unit.py
+++ b/lobster/core/unit.py
@@ -364,8 +364,18 @@ class UnitStore:
                     False))
 
             for id, file, run, lumi, arg, failed in rows:
-                if (run, lumi) in all_lumis or failed > self.config.advanced.threshold_for_failure:
-                    logger.debug("skipping run {}, lumi {} with failure count {}".format(run, lumi, failed))
+                if (run, lumi) in all_lumis:
+                    logger.debug("skipping duplicate run {}, lumi {}".format(run, lumi))
+                    continue
+
+                if failed > self.config.advanced.threshold_for_failure:
+                    logger.debug("skipping run {}, "\
+                        "lumi {} "\
+                        "with failure count {} "\
+                        "exceeding `config.advanced.threshold_for_failure={}`".format(
+                            run, lumi, failed, self.config.advanced.threshold_for_failure
+                        )
+                    )
                     continue
 
                 if current_size == 0:

--- a/lobster/core/unit.py
+++ b/lobster/core/unit.py
@@ -364,7 +364,7 @@ class UnitStore:
                     False))
 
             for id, file, run, lumi, arg, failed in rows:
-                if (run, lumi) in all_lumis:
+                if (run, lumi, arg) in all_lumis:
                     logger.debug("skipping duplicate run {}, lumi {}".format(run, lumi))
                     continue
 
@@ -388,7 +388,7 @@ class UnitStore:
                     continue
 
                 if lumi > 0:
-                    all_lumis.add((run, lumi))
+                    all_lumis.add((run, lumi, arg))
                     for (ls_id, ls_file, ls_run, ls_lumi) in self.db.execute("""
                             select
                                 id, file, run, lumi


### PR DESCRIPTION
@matz-e: I'm pretty sure that moving `unique_arguments` from the workflow to the dataset specification is the way to go here. Unfortunately it required a lot of redundant copying around. Let me know if you think of a more elegant way to do it and I'll update the branch.