### PR TITLE
Fix total lumis

### DIFF
--- a/lobster/cmssw/dataset.py
+++ b/lobster/cmssw/dataset.py
@@ -146,6 +146,6 @@ class Dataset(Configurable):
                         if not mask or ((run['run_num'], lumi) in unmasked_lumis):
                             result.files[fn].lumis.append((run['run_num'], lumi))
 
-        result.masked_lumis = result.unmasked_lumis - result.total_lumis
+        result.masked_lumis = result.total_lumis - result.unmasked_lumis
 
         return result

--- a/lobster/cmssw/dataset.py
+++ b/lobster/cmssw/dataset.py
@@ -122,6 +122,7 @@ class Dataset(Configurable):
         if infos is None:
             raise IOError('dataset {} contains no files'.format(dataset))
         result.total_events = sum([info['num_event'] for info in infos])
+        result.total_lumis = sum([info['num_lumi'] for info in infos])
         result.unmasked_lumis = sum([info['num_lumi'] for info in infos])
 
         for info in self.__apis[instance].listFiles(dataset=dataset, detail=True):
@@ -145,7 +146,6 @@ class Dataset(Configurable):
                         if not mask or ((run['run_num'], lumi) in unmasked_lumis):
                             result.files[fn].lumis.append((run['run_num'], lumi))
 
-        result.total_lumis = sum([len(f.lumis) for f in result.files.values()])
         result.masked_lumis = result.unmasked_lumis - result.total_lumis
 
         return result

--- a/lobster/cmssw/dataset.py
+++ b/lobster/cmssw/dataset.py
@@ -107,7 +107,7 @@ class Dataset(Configurable):
 
             Dataset.__dsets[self.dataset] = res
 
-        self.total_units = Dataset.__dsets[self.dataset].total_lumis
+        self.total_units = sum([len(f.lumis) for f in Dataset.__dsets[self.dataset].files.values()])
         return Dataset.__dsets[self.dataset]
 
     def query_database(self, dataset, instance, mask, file_based):


### PR DESCRIPTION
I think this gives what we should expect, using @klannon's dataset as a test case:

```
>>> from lobster import cmssw
>>> dset = cmssw.Dataset(dataset='/SingleMuMinusFlatPt0p2To150/TTI2023Upg14D-PU140bx25_PH2_1K_FB_V3-v2/GEN-SIM-DIGI-RAW', events_per_task=1000)
>>> info = dset.get_info()
>>> info.total_lumis
1001
>>> info.unmasked_lumis
1001
>>> info.masked_lumis
0
>>> dset.total_units
1681
```

I think this is the distinction between lumis and units that we want to make-- lumis should be unique, units should be the smallest pieces of work we can do (so one split lumi across two files is two units).