### PR TITLE
Fix lumi counting

### DIFF
--- a/lobster/cmssw/dataset.py
+++ b/lobster/cmssw/dataset.py
@@ -135,17 +135,18 @@ class Dataset(Configurable):
         else:
             blocks = self.__apis[instance].listBlocks(dataset=dataset)
             if mask:
-                unmasked_units = LumiList(filename=mask)
+                unmasked_lumis = LumiList(filename=mask)
             for block in blocks:
                 runs = self.__apis[instance].listFileLumis(block_name=block['block_name'])
                 for run in runs:
                     fn = run['logical_file_name']
                     for lumi in run['lumi_section_num']:
-                        if not mask or ((run['run_num'], lumi) in unmasked_units):
+                        if not mask or ((run['run_num'], lumi) in unmasked_lumis):
                             result.files[fn].lumis.append((run['run_num'], lumi))
+                        elif mask and ((run['run_num'], lumi) not in unmasked_lumis):
+                            result.masked_units += 1
 
-        result.total_units = sum([len(f.lumis) for f in result.files.values()])
-        result.unmasked_units = len(unmasked_units) if mask else result.total_units
-        result.masked_units = result.total_units - result.unmasked_units
+        result.unmasked_units = sum([len(f.lumis) for f in result.files.values()])
+        result.total_units = result.unmasked_units + result.masked_units
 
         return result

--- a/lobster/cmssw/dataset.py
+++ b/lobster/cmssw/dataset.py
@@ -146,6 +146,6 @@ class Dataset(Configurable):
                             result.files[fn].lumis.append((run['run_num'], lumi))
 
         result.total_units = sum([len(f.lumis) for f in result.files.values()])
-        result.masked_units = result.unmasked_units - result.total_units
+        result.masked_units = result.total_units - result.unmasked_units
 
         return result

--- a/lobster/cmssw/dataset.py
+++ b/lobster/cmssw/dataset.py
@@ -122,7 +122,6 @@ class Dataset(Configurable):
         if infos is None:
             raise IOError('dataset {} contains no files'.format(dataset))
         result.total_events = sum([info['num_event'] for info in infos])
-        result.unmasked_units = sum([info['num_lumi'] for info in infos])
 
         for info in self.__apis[instance].listFiles(dataset=dataset, detail=True):
             fn = info['logical_file_name']
@@ -146,6 +145,7 @@ class Dataset(Configurable):
                             result.files[fn].lumis.append((run['run_num'], lumi))
 
         result.total_units = sum([len(f.lumis) for f in result.files.values()])
+        result.unmasked_units = len(unmasked_units) if mask else result.total_units
         result.masked_units = result.total_units - result.unmasked_units
 
         return result

--- a/lobster/core/dataset.py
+++ b/lobster/core/dataset.py
@@ -25,9 +25,9 @@ class DatasetInfo(object):
         self.files = defaultdict(FileInfo)
         self.tasksize = 1
         self.total_events = 0
-        self.total_lumis = 0
-        self.unmasked_lumis = 0
-        self.masked_lumis = 0
+        self.total_units = 0
+        self.unmasked_units = 0
+        self.masked_units = 0
 
     def __repr__(self):
         descriptions = ['{a}={v}'.format(a=attribute, v=getattr(self, attribute)) for attribute in self.__dict__]
@@ -68,7 +68,7 @@ class Dataset(Configurable):
                 files += filter(fs.isfile, fs.ls(entry))
             elif fs.isfile(entry):
                 files.append(entry)
-        dset.total_lumis = len(files)
+        dset.total_units = len(files)
         self.total_units = len(files)
 
         for fn in files:
@@ -114,7 +114,7 @@ class ProductionDataset(Configurable):
         if self.events_per_lumi:
             nlumis = int(math.ceil(float(self.events_per_task) / self.events_per_lumi))
         dset.files[None].lumis = [(1, x) for x in range(1, ntasks * nlumis + 1, nlumis)]
-        dset.total_lumis = ntasks
+        dset.total_units = ntasks
         self.total_units = ntasks * nlumis
 
         return dset
@@ -148,6 +148,6 @@ class ParentDataset(Configurable):
         dset = DatasetInfo()
         dset.file_based = False
         dset.tasksize = self.units_per_task
-        dset.total_lumis = self.total_units
+        dset.total_units = self.total_units
 
         return dset

--- a/lobster/core/unit.py
+++ b/lobster/core/unit.py
@@ -668,7 +668,7 @@ class UnitStore:
                 events,
                 ifnull((select sum(events_read) from tasks where status in (2, 6, 8) and type = 0 and workflow = workflows.id), 0),
                 ifnull((select sum(events_written) from tasks where status in (2, 6, 8) and type = 0 and workflow = workflows.id), 0),
-                units + units_masked,
+                units,
                 units,
                 units_done,
                 units_paused,

--- a/lobster/core/unit.py
+++ b/lobster/core/unit.py
@@ -677,7 +677,7 @@ class UnitStore:
                     1) || ' %'
             from workflows""")
 
-        yield "Label Events read written Units unmasked done paused failed skipped Completion".split()
+        yield "Label Events read written Units unmasked written paused failed skipped Progress".split()
         total = None
         for row in cursor:
             failed, skipped = self.db.execute("""

--- a/lobster/core/unit.py
+++ b/lobster/core/unit.py
@@ -189,9 +189,9 @@ class UnitStore:
                            dataset_info.file_based,
                            dataset_info.tasksize,
                            taskruntime,
-                           dataset_info.total_lumis * len(unique_args),
-                           dataset_info.masked_lumis,
-                           dataset_info.total_lumis * len(unique_args),
+                           dataset_info.total_units * len(unique_args),
+                           dataset_info.masked_units,
+                           dataset_info.total_units * len(unique_args),
                            dataset_info.total_events))
 
         self.db.execute("""create table if not exists files_{0}(

--- a/lobster/core/unit.py
+++ b/lobster/core/unit.py
@@ -669,7 +669,7 @@ class UnitStore:
                 ifnull((select sum(events_read) from tasks where status in (2, 6, 8) and type = 0 and workflow = workflows.id), 0),
                 ifnull((select sum(events_written) from tasks where status in (2, 6, 8) and type = 0 and workflow = workflows.id), 0),
                 units,
-                units,
+                units - units_masked,
                 units_done,
                 units_paused,
                 '' || round(

--- a/test/test_cms_backend.py
+++ b/test/test_cms_backend.py
@@ -52,7 +52,7 @@ class TestSQLBackend(object):
         for fn in ['/test/{0}.root'.format(i) for i in range(files)]:
             info.files[fn].lumis = [(-1, -1)]
 
-        info.total_lumis = len(info.files.keys())
+        info.total_units = len(info.files.keys())
         info.path = ''
 
         return Workflow(label, None, sandbox_release=''), info
@@ -101,7 +101,7 @@ class TestSQLBackend(object):
             info.files[f].events = file_events
             info.files[f].lumis = file_lumis
 
-        info.total_lumis = sum([len(finfo.lumis) for f, finfo in info.files.items()])
+        info.total_units = sum([len(finfo.lumis) for f, finfo in info.files.items()])
 
         return Workflow(label, None, sandbox_release=''), info
         # }}}


### PR DESCRIPTION
This respects the distinction between lumis and units that we want to make-- lumis should be unique (run, lumi) pairs, units should be the smallest pieces of work we can do (so one split lumi across two files is two units).
Here's what we get on the master branch, looking at @klannon's dataset:
![screen shot 2016-04-10 at 2 10 40 am](https://cloud.githubusercontent.com/assets/5114833/14408416/5b960222-fec2-11e5-8d60-78d4a798d945.png)
And here's what this PR introduces:
![screen shot 2016-04-10 at 2 19 09 am](https://cloud.githubusercontent.com/assets/5114833/14408430/acd456c0-fec2-11e5-8ff4-fa1b56d6ff91.png)

Note that this doesn't fix the missing events yet.
