### PR TITLE
Find missing events

### DIFF
--- a/lobster/core/task.py
+++ b/lobster/core/task.py
@@ -75,9 +75,11 @@ class TaskHandler(object):
                         unit_update.append((unit.FAILED, lumi_id))
                         units_processed -= 1
                 elif not self._file_based:
-                    file_lumis = set(map(tuple, files_info[file][1]))
+                    file_lumis = set(files_info[file][1])
                     for (lumi_id, lumi_file, r, l) in file_units:
+                        logger.error('FILE UNITS %s' % file_units)
                         if (r, l) not in file_lumis:
+                            logger.error('FILE LUMIS %s' % file_lumis)
                             unit_update.append((unit.FAILED, lumi_id))
                             units_processed -= 1
 

--- a/lobster/core/unit.py
+++ b/lobster/core/unit.py
@@ -102,7 +102,8 @@ class UnitStore:
             pset_hash text default null,
             publish_label text,
             release text,
-            uuid text)""")
+            uuid text,
+            single_file_max)""")
         self.db.execute("""create table if not exists tasks(
             bytes_bare_output int default 0 not null,
             bytes_output int default 0 not null,
@@ -176,8 +177,9 @@ class UnitStore:
                        units,
                        units_masked,
                        units_left,
-                       events)
-                       values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""", (
+                       events,
+                       single_file_max)
+                       values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""", (
                            wflow.label,
                            label,
                            wflow.label,
@@ -192,7 +194,8 @@ class UnitStore:
                            dataset_info.total_units * len(unique_args),
                            dataset_info.masked_units,
                            dataset_info.total_units * len(unique_args),
-                           dataset_info.total_events))
+                           dataset_info.total_events,
+                           getattr(wflow, 'single_file_max', False)))
 
         self.db.execute("""create table if not exists files_{0}(
             id integer primary key autoincrement,
@@ -297,8 +300,8 @@ class UnitStore:
                 Factor to apply to the tasksize.
         """
         with self.db:
-            workflow_id, tasksize = self.db.execute(
-                    "select id, tasksize from workflows where label=?",
+            workflow_id, tasksize, single_file_max = self.db.execute(
+                    "select id, tasksize, single_file_max from workflows where label=?",
                     (workflow,)).fetchone()
 
             logger.debug(("creating {0} task(s) for workflow {1}:" +
@@ -335,6 +338,7 @@ class UnitStore:
                     select id, file, run, lumi, arg, failed
                     from units_{0}
                     where file in ({1}) and status not in (1, 2, 6, 7, 8)
+                    order by file
                     """.format(workflow, ', '.join('?' for _ in chunk)), chunk))
 
             logger.debug("creating tasks from {} files, {} units".format(len(files), len(rows)))
@@ -342,9 +346,6 @@ class UnitStore:
             # files and lumis for individual tasks
             files = set()
             units = []
-
-            # lumi veto to avoid duplicated processing
-            all_lumis = set()
 
             # task container and current task size
             tasks = []
@@ -364,11 +365,6 @@ class UnitStore:
                     False))
 
             for id, file, run, lumi, arg, failed in rows:
-                if (run, lumi, arg) in all_lumis:
-                    logger.debug("skipping already processed unit with "\
-                            "run {}, lumi {}, arg {}".format(run, lumi, arg))
-                    continue
-
                 if failed > self.config.advanced.threshold_for_failure:
                     logger.debug("skipping run {}, "\
                         "lumi {} "\
@@ -379,41 +375,22 @@ class UnitStore:
                     )
                     continue
 
-                if current_size == 0:
-                    if num <= 0:
-                        break
-
                 if failed == self.config.advanced.threshold_for_failure:
                     logger.debug("creating isolation task for run {}, lumi {} with failure count {}".format(run, lumi, failed))
                     insert_task([file], [(id, file, run, lumi)], arg)
                     continue
 
-                if lumi > 0:
-                    all_lumis.add((run, lumi, arg))
-                    if arg is not None:
-                        cursor = self.db.execute("""
-                            select id, file, run, lumi
-                            from units_{0}
-                            where
-                                run=? and lumi=? and arg=? and
-                                status not in (1, 2, 6, 7, 8) and
-                                failed < ?""".format(workflow),
-                                (run, lumi, arg, self.config.advanced.threshold_for_failure))
-                    else:
-                        cursor = self.db.execute("""
-                            select id, file, run, lumi
-                            from units_{0}
-                            where
-                                run=? and lumi=? and
-                                status not in (1, 2, 6, 7, 8) and
-                                failed < ?""".format(workflow),
-                                (run, lumi, self.config.advanced.threshold_for_failure))
-                    for (ls_id, ls_file, ls_run, ls_lumi) in cursor:
-                        units.append((ls_id, ls_file, ls_run, ls_lumi))
-                        files.add(ls_file)
-                else:
-                    units.append((id, file, run, lumi))
-                    files.add(file)
+                if single_file_max and (len(files) == 1) and (file not in files):
+                    insert_task(files, units, arg)
+
+                    files = set()
+                    units = []
+
+                    current_size = 0
+                    num -= 1
+
+                units.append((id, file, run, lumi))
+                files.add(file)
 
                 current_size += 1
 
@@ -425,6 +402,10 @@ class UnitStore:
 
                     current_size = 0
                     num -= 1
+
+                if current_size == 0:
+                    if num <= 0:
+                        break
 
             if current_size > 0:
                 insert_task(files, units, arg)

--- a/test/count_events.py
+++ b/test/count_events.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+import argparse
+import glob
+import itertools
+import numpy as np
+import os
+
+import DataFormats.FWLite
+
+parser = argparse.ArgumentParser(description='count unique events in directories of edm files')
+parser.add_argument('paths', nargs='+', help='directories to analyze')
+parser.add_argument('--max', type=int, default=200000, help='max events to analyze')
+parser.add_argument('--verbose', action='store_true', help='print progress')
+args = parser.parse_args()
+
+events = {}
+for path in args.paths:
+    files = glob.glob('{}/*.root'.format(path))
+
+    events[path] = np.zeros(args.max, dtype='int32, int32, int32')
+    for index, event in enumerate(DataFormats.FWLite.Events(files)):
+        if index > args.max:
+            break
+
+        r = event.object().id().run()
+        l = event.object().id().luminosityBlock()
+        e = event.object().id().event()
+
+        events[path][index] = (r, l, e)
+
+        if args.verbose and index % 500 == 0:
+            print '>>>> entry run lumi event: {:10} {:10} {:10} {:10}'.format(index, r, l, e)
+
+    events[path] = events[path][:index+1]
+
+    degenerate = len(events[path])
+    events[path] = np.unique(events[path])
+    unique = len(events[path])
+
+    print 'found {} ({} unique) run, lumi, event sets in {} files in path {}'.format(degenerate, unique, len(files), path)
+
+if len(args.paths) > 1:
+    for first, second in itertools.permutations(args.paths, 2):
+        diff = np.setdiff1d(events[first], events[second])
+        print 'path {} has {} events which are not in {}'.format(first, len(diff), second)

--- a/test/test_cms_backend.py
+++ b/test/test_cms_backend.py
@@ -101,9 +101,14 @@ class TestSQLBackend(object):
             info.files[f].events = file_events
             info.files[f].lumis = file_lumis
 
-        info.total_units = sum([len(finfo.lumis) for f, finfo in info.files.items()])
+        lumis = sum([finfo.lumis for finfo in info.files.values()], [])
+        info.total_units = len(lumis)
+        total_lumis = len(set(lumis))
 
-        return Workflow(label, None, sandbox_release=''), info
+        wflow = Workflow(label, None, sandbox_release='')
+        wflow.single_file_max = (total_lumis != info.total_units)
+
+        return wflow, info
         # }}}
 
     def test_create_datasets(self):
@@ -129,8 +134,7 @@ class TestSQLBackend(object):
         handler = TaskHandler(123, 'test_handler', files, lumis, 'test', True)
 
         files_info = {
-                u'/test/0.root': (220, [(1, 1), (1, 2), (1, 3)]),
-                u'/test/1.root': (80, [(1, 3)])
+                u'/test/0.root': (220, [(1, 1), (1, 2), (1, 3)])
         }
         files_skipped = []
         events_written = 123
@@ -139,11 +143,11 @@ class TestSQLBackend(object):
         file_update, unit_update = \
                 handler.get_unit_info(False, update, files_info, files_skipped, events_written)
 
-        assert update.units_processed == 4
-        assert update.events_read == 300
+        assert update.units_processed == 3
+        assert update.events_read == 220
         assert update.events_written == 123
         assert update.status == 2
-        assert file_update == [(220, 0, 1), (80, 0, 2)]
+        assert file_update == [(220, 0, 1)]
         assert unit_update == []
         # }}}
 
@@ -163,7 +167,7 @@ class TestSQLBackend(object):
             from workflows where label=?""",
             (label,)).fetchone()
 
-        assert jr == 4
+        assert jr == 3
         assert jd == 0
         assert er in (0, None)
         assert ew in (0, None)
@@ -175,11 +179,25 @@ class TestSQLBackend(object):
         assert jd == 0
         # }}}
 
+    def test_obtain_split(self):
+        # {{{
+        self.interface.register_dataset(
+                *self.create_dbs_dataset(
+                    'test_obtain_split', lumis=20, filesize=2.2, tasksize=10))
+        (id, label, files, lumis, arg, _) = self.interface.pop_units('test_obtain_split', 1)[0]
+
+        (single_file_max,) = self.interface.db.execute(
+                "select single_file_max from workflows where label=?", ('test_obtain_split',)).fetchone()
+
+        assert len(files) == 1
+        assert single_file_max == 1
+       # }}}
+
     def test_return_good(self):
         # {{{
         self.interface.register_dataset(
                 *self.create_dbs_dataset(
-                    'test_good', lumis=20, filesize=2.2, tasksize=6))
+                    'test_good', lumis=20, filesize=3.0, tasksize=6))
         (id, label, files, lumis, arg, _) = self.interface.pop_units('test_good', 1)[0]
 
         task_update = TaskUpdate(host='hostname', id=id)
@@ -188,9 +206,8 @@ class TestSQLBackend(object):
                 False,
                 task_update,
                 {
-                    '/test/0.root': (220, [(1, 1), (1, 2), (1, 3)]),
-                    '/test/1.root': (220, [(1, 3), (1, 4), (1, 5)]),
-                    '/test/2.root': (60, [(1, 5)])
+                    '/test/0.root': (300, [(1, 1), (1, 2), (1, 3)]),
+                    '/test/1.root': (60, [(1, 4), (1, 5), (1, 6)])
                 },
                 [],
                 100
@@ -208,8 +225,8 @@ class TestSQLBackend(object):
             (label,)).fetchone()
 
         assert jr == 0
-        assert jd == 7
-        assert er == 500
+        assert jd == 6
+        assert er == 360
         assert ew == 100
 
         (id, jr, jd, er) = self.interface.db.execute(
@@ -217,15 +234,60 @@ class TestSQLBackend(object):
 
         assert jr == 0
         assert jd == 3
-        assert er == 220
+        assert er == 300
 
         (id, jr, jd, er) = self.interface.db.execute(
-                "select id, units_running, units_done, events_read from files_test_good where filename='/test/2.root'").fetchone()
+                "select id, units_running, units_done, events_read from files_test_good where filename='/test/1.root'").fetchone()
 
         assert jr == 0
-        assert jd == 1
+        assert jd == 3
         assert er == 60
         # }}}
+
+    def test_return_good_split(self):
+        # {{{
+        self.interface.register_dataset(
+                *self.create_dbs_dataset(
+                    'test_good_split', lumis=20, filesize=2.2, tasksize=6))
+
+        (id, label, files, lumis, arg, _) = self.interface.pop_units('test_good_split', 1)[0]
+
+        task_update = TaskUpdate(host='hostname', id=id)
+        handler = TaskHandler(id, label, files, lumis, None, True)
+        file_update, unit_update = handler.get_unit_info(
+                False,
+                task_update,
+                {
+                    '/test/0.root': (220, [(1, 1), (1, 2), (1, 3)]),
+                },
+                [],
+                100
+                )
+
+        self.interface.update_units({(label, "units_" + label): [(task_update, file_update, unit_update)]})
+
+        (jr, jd, er, ew) = self.interface.db.execute("""
+            select
+                units_running,
+                units_done,
+                (select sum(events_read) from tasks where status in (2, 6, 8) and type = 0 and workflow = workflows.id),
+                (select sum(events_written) from tasks where status in (2, 6, 8) and type = 0 and workflow = workflows.id)
+            from workflows where label=?""",
+            (label,)).fetchone()
+
+        assert jr == 0
+        assert jd == 3
+        assert er == 220
+        assert ew == 100
+
+        (id, jr, jd, er) = self.interface.db.execute(
+                "select id, units_running, units_done, events_read from files_test_good_split where filename='/test/0.root'").fetchone()
+
+        assert jr == 0
+        assert jd == 3
+        assert er == 220
+        # }}}
+
 
     def test_return_bad(self):
         # {{{
@@ -324,7 +386,7 @@ class TestSQLBackend(object):
         # {{{
         self.interface.register_dataset(
                 *self.create_dbs_dataset(
-                    'test_ugly', lumis=11, filesize=2.2, tasksize=6))
+                    'test_ugly', lumis=11, filesize=3, tasksize=6))
         (id, label, files, lumis, arg, _) = self.interface.pop_units('test_ugly', 1)[0]
 
         task_update = TaskUpdate(host='hostname', id=id)
@@ -335,7 +397,7 @@ class TestSQLBackend(object):
                 {
                     '/test/0.root': (120, [(1, 2), (1, 3)])
                 },
-                ['/test/1.root', '/test/2.root'],
+                ['/test/1.root'],
                 50
                 )
 
@@ -345,7 +407,7 @@ class TestSQLBackend(object):
                 self.interface.db.execute(
                     "select skipped from files_{0}".format(label)))
 
-        assert skipped == [(0,), (1,), (1,), (0,), (0,)]
+        assert skipped == [(0,), (1,), (0,), (0,)]
 
         status = list(
                 self.interface.db.execute(
@@ -365,7 +427,7 @@ class TestSQLBackend(object):
 
         assert jr == 0
         assert jd == 2
-        assert jl == 13
+        assert jl == 9
         assert er == 120
         assert ew == 50
 
@@ -386,7 +448,7 @@ class TestSQLBackend(object):
         # {{{
         self.interface.register_dataset(
                 *self.create_dbs_dataset(
-                    'test_uglier', lumis=11, filesize=2.2, tasksize=6))
+                    'test_uglier', lumis=15, filesize=3, tasksize=8))
         (id, label, files, lumis, arg, _) = self.interface.pop_units('test_uglier', 1)[0]
 
         task_update = TaskUpdate(host='hostname', id=id, submissions=1)
@@ -395,8 +457,8 @@ class TestSQLBackend(object):
                 False,
                 task_update,
                 {
-                    '/test/0.root': (220, [(1, 1), (1, 2), (1, 3)]),
-                    '/test/1.root': (220, [(1, 3), (1, 4), (1, 5)]),
+                    '/test/0.root': (300, [(1, 1), (1, 2), (1, 3)]),
+                    '/test/1.root': (300, [(1, 4), (1, 5), (1, 6)]),
                 },
                 ['/test/2.root'],
                 100
@@ -413,9 +475,9 @@ class TestSQLBackend(object):
                 False,
                 task_update,
                 {
-                    '/test/2.root': (220, [(1, 5), (1, 6), (1, 7)]),
-                    '/test/3.root': (220, [(1, 7), (1, 8), (1, 9)]),
-                    '/test/4.root': (20, [(1, 9)]),
+                    '/test/2.root': (300, [(1, 7), (1, 8), (1, 9)]),
+                    '/test/3.root': (300, [(1, 10), (1, 11), (1, 12)]),
+                    '/test/4.root': (100, [(1, 13)]),
                 },
                 [],
                 100
@@ -436,7 +498,7 @@ class TestSQLBackend(object):
         assert jr == 0
         assert jd == 13
         assert jl == 2
-        assert er == 900
+        assert er == 1300
         assert ew == 200
         # }}}
 


### PR DESCRIPTION
We currently do '[lumi-mending](https://github.com/matz-e/lobster/blob/master/lobster/core/unit.py#L395)' of split lumis, where we pick a (run, lumi) that hasn't been finished, then do a second query to find all of the files with that (run, lumi) in it and add those to the processing of the current task. To try and debug the missing events issue, I wrote a little [script](https://github.com/matz-e/lobster/blob/find-missing-events/test/count_events.py) to count the unique events in a dataset.

Looking at the original dataset, to double check this isn't a problem in DAS (I copied it locally for faster debugging):

```
~/lobster/test >python count_events.py /hadoop/store/user/awoodard/minus
found 168000 (100000 unique) run, lumi, event sets in 192 files in path /hadoop/store/user/awoodard/minus
```

Here is the [result](http://www.crc.nd.edu/~awoodard/lobster/simple_crustacean_7be2ff1_v1/) of running with the master branch:

```
~/lobster/test >python count_events.py /hadoop/store/user/awoodard/simple_crustacean_7be2ff1_v1/minus/
found 100000 (100000 unique) run, lumi, event sets in 174 files in path /hadoop/store/user/awoodard/simple_crustacean_7be2ff1_v1/minus/
```

Here is the [result](http://www.crc.nd.edu/~awoodard/lobster/simple_crustacean_ba3a0a6_v1/) of running with the lumi-mending removed (this branch):

```
(.lobster)[earth] ~/lobster/test >python count_events.py /hadoop/store/user/awoodard/simple_crustacean_ba3a0a6_v1/minus/
found 167300 (100000 unique) run, lumi, event sets in 403 files in path /hadoop/store/user/awoodard/simple_crustacean_ba3a0a6_v1/minus/
```

So in @klannon's dataset, there are a large number of duplicate run, lumi, event sets. I don't think we want to throw events away just because they have duplicate run, lumi, event sets (for MC, at least.) I can think of innocuous scenarios leading to duplicates where the events themselves are perfectly useful (as long as the random seed is not fixed.) What is the use case we are trying to protect against-- mistakes upstream that result in real duplication of data? I think we need at least a knob to turn off lumi mending, although my vote would be to remove it completely (which this PR does) in order to keep things simpler. @matz-e, @klannon: opinions?

Fixes #319.
