### PR TITLE
Only delete files which are not needed anymore. Fixes #330.

### DIFF
--- a/lobster/core/unit.py
+++ b/lobster/core/unit.py
@@ -923,3 +923,14 @@ class UnitStore:
             self.db.executemany("update tasks set status=3 where id=?", [(task,) for task in tasks])
             # reset merged tasks from merging
             self.db.executemany("update tasks set status=2 where task=?", [(task,) for task in tasks])
+
+    def finished_files(self, infos):
+        res = []
+        for label, files in infos.items():
+            res.extend(self.db.execute("""select filename
+                from files_{0}
+                where id in ({1}) and
+                (units_done == units)""".format(label, ', '.join('?' for _ in files)), tuple(files))
+            )
+
+        return (x[0] for x in res)


### PR DESCRIPTION
Better tested-- this time I'm not throwing away work that we need!

Unfortunately, this requires an additional DB query in order to find out which files are still needed by other tasks. But the query will only be made if you've specified to cleanup inputs.