### PR TITLE
Add fallback summary

### DIFF
--- a/lobster/commands/data/category.html
+++ b/lobster/commands/data/category.html
@@ -184,6 +184,26 @@
             <a href="cpu-wall-hist.png"><img alt="" src="cpu-wall-hist.png"/></a>
             <a href="cpu-wall-int-hist.png"><img alt="" src="cpu-wall-int-hist.png"/></a>
         {% endif %}
+        {% if good_tasks or bad_tasks %}
+	    <h3>Transfer Protocol Summary</h3>
+    	    <table class="fancy">
+	    <tr>
+	        <th>Protocol</th>
+	        <th>Stage-in Success</th>
+	        <th>Stage-in Failure</th>
+	        <th>Stageout Success</th>
+	        <th>Stageout Failure</th>
+	    </tr>
+	    {% for protocol in transfers %}
+	    <tr {{ loop.cycle('', 'class="alt"') }}>
+	        <td>{{ protocol }}</td>
+	        <td>{{ transfers[protocol]['stage-in success'] }}</td>
+	        <td>{{ transfers[protocol]['stage-in failure'] }}</td>
+	        <td>{{ transfers[protocol]['stageout success'] }}</td>
+	        <td>{{ transfers[protocol]['stageout failure'] }}</td>
+	    </tr>
+	    {% endfor %}
+	    </table>
         {% endif %}
         </div>
 

--- a/lobster/commands/data/category.html
+++ b/lobster/commands/data/category.html
@@ -205,6 +205,7 @@
 	    {% endfor %}
 	    </table>
         {% endif %}
+        {% endif %}
         </div>
 
         <h2 id="navgood">Successful Tasks</h2>

--- a/lobster/commands/plot.py
+++ b/lobster/commands/plot.py
@@ -1,5 +1,6 @@
 # vim: fileencoding=utf-8
 
+from collections import defaultdict, Counter
 from datetime import datetime
 import glob
 import gzip
@@ -14,6 +15,7 @@ import time
 import yaml
 import re
 import string
+import json
 
 import matplotlib
 matplotlib.use('Agg')
@@ -325,6 +327,7 @@ class Plotter(object):
         start_units = 0
         completed_units = []
         units_processed = {}
+        transfers = {}
         for (label,) in db.execute("select label from workflows"):
             total_units += db.execute("select count(*) from units_{0}".format(label)).fetchone()[0]
             start_units += db.execute("""
@@ -347,10 +350,14 @@ class Plotter(object):
                 from units_{0}, tasks
                 where units_{0}.task == tasks.id
                     and (units_{0}.status in (2, 6))""".format(label)).fetchall()
+            transfers[label] = json.loads(db.execute("""
+                select transfers
+                from workflows
+                where label=?""", (label,)).fetchone()[0])
 
         logger.debug('finished reading database')
 
-        return success_tasks, failed_tasks, summary_data, np.concatenate(completed_units), total_units, total_units - start_units, units_processed
+        return success_tasks, failed_tasks, summary_data, np.concatenate(completed_units), total_units, total_units - start_units, units_processed, transfers
 
     def readlog(self, filename=None, category='all'):
         if filename:
@@ -618,6 +625,20 @@ class Plotter(object):
             host_tasks = failed_tasks[failed_tasks['host'] == h]
             table.append([h, c] + [len(host_tasks[host_tasks['exit_code'] == f]) for f in failures])
         return table
+
+    def merge_transfers(self, transfers, labels):
+        res = defaultdict(lambda: Counter({
+                'stage-in success': 0,
+                'stageout success': 0,
+                'stage-in failure': 0,
+                'stageout failure': 0
+        }))
+
+        for label in labels:
+            for protocol in transfers[label]:
+                res[protocol].update(Counter(transfers[label][protocol]))
+
+        return res
 
     def make_master_plots(self, category, good_tasks, success_tasks):
         headers, stats = self.__category_stats[category]
@@ -958,7 +979,7 @@ class Plotter(object):
                 continue
             self.__category_stats[label] = self.readlog(category=label)
 
-        good_tasks, failed_tasks, summary_data, completed_units, total_units, start_units, units_processed = self.readdb()
+        good_tasks, failed_tasks, summary_data, completed_units, total_units, start_units, units_processed, transfers = self.readdb()
 
         success_tasks = good_tasks[good_tasks['type'] == 0] if len(good_tasks) > 0 else np.array([], good_tasks.dtype)
         merge_tasks = good_tasks[good_tasks['type'] == 1] if len(good_tasks) > 0 else np.array([], good_tasks.dtype)
@@ -1032,6 +1053,8 @@ class Plotter(object):
         edges = self.make_master_plots('all', good_tasks, success_tasks)
         logs = self.make_workflow_plots('all', edges, good_tasks, failed_tasks, success_tasks, merge_tasks, xmin, xmax)
 
+        labels = [w.label for w in self.config.workflows]
+
         with open(os.path.join(self.__plotdir, 'all', 'index.html'), 'w') as f:
             f.write(wflow.render(
                 id=self.config.label,
@@ -1044,7 +1067,8 @@ class Plotter(object):
                 bad_logs=logs,
                 bad_hosts=self.find_failure_hosts(failed_tasks),
                 foremen=foremen_names,
-                categories=categories
+                categories=categories,
+                transfers=self.merge_transfers(transfers, labels)
             ).encode('utf-8'))
 
         def add_total(summaries):
@@ -1099,7 +1123,8 @@ class Plotter(object):
                     bad_logs=logs,
                     bad_hosts=self.find_failure_hosts(wf_failed_tasks),
                     foremen=foremen_names,
-                    categories=categories
+                    categories=categories,
+                    transfers=self.merge_transfers(transfers, labels)
                 ).encode('utf-8'))
 
         with open(os.path.join(self.__plotdir, 'index.html'), 'w') as f:

--- a/lobster/commands/plot.py
+++ b/lobster/commands/plot.py
@@ -634,10 +634,16 @@ class Plotter(object):
         )
 
         for resource, unit in (('cores', ''), ('memory', '/ MB'), ('disk', '/ MB')):
+            scale = 1
+            if unit == '/ MB' \
+                    and max(stats[:,headers['total_' + resource]]) > 1000 \
+                    and max(stats[:,headers['committed_' + resource]]) > 1000:
+                scale = 1000
+                unit = '/ GB'
             self.plot(
                     [
-                        (stats[:,headers['timestamp']], stats[:,headers['total_' + resource]]),
-                        (stats[:,headers['timestamp']], stats[:,headers['committed_' + resource]])
+                        (stats[:,headers['timestamp']], stats[:,headers['total_' + resource]] / scale),
+                        (stats[:,headers['timestamp']], stats[:,headers['committed_' + resource]] / scale)
                     ],
                     '{} {}'.format(resource[0].upper() + resource[1:], unit).strip(),
                     os.path.join(category, resource),

--- a/lobster/commands/process.py
+++ b/lobster/commands/process.py
@@ -213,7 +213,7 @@ class Process(Command):
                 categories.append(category.name)
                 self.setup_logging(category.name)
             self.queue.specify_max_category_resources(category.name, constraints)
-            logger.debug('Category {0}: {1}'.format(category.name ,constraints))
+            logger.debug('Category {0}: {1}'.format(category.name, constraints))
             if 'wall_time' not in constraints:
                 self.queue.activate_fast_abort_category(category.name, abort_multiplier)
 

--- a/lobster/core/data/task.py
+++ b/lobster/core/data/task.py
@@ -770,12 +770,12 @@ target_se = config['default se']
 logger.info("using sync CE {}".format(sync_ce))
 
 parameters = {
-            'ExeStart': str(config['executable']),
-            'NCores': config.get('cores', 1),
-            'SyncCE': sync_ce,
-            'SyncGridJobId': syncid,
-            'WNHostName': socket.getfqdn()
-            }
+    'ExeStart': str(config['executable']),
+    'NCores': config.get('cores', 1),
+    'SyncCE': sync_ce,
+    'SyncGridJobId': syncid,
+    'WNHostName': socket.getfqdn()
+}
 
 apmonSend(taskid, monitorid, parameters, logging.getLogger('mona'), monalisa)
 apmonFree()
@@ -919,20 +919,20 @@ logger.debug("Reporting StageOutSE {}".format(stageout_se))
 logger.debug("Reporting StageOutExitCode {}".format(stageout_exit_code))
 
 parameters = {
-            'ExeTime': str(exe_time),
-            'ExeExitCode': str(exe_exit_code),
-            'JobExitCode': str(task_exit_code),
-            'JobExitReason': '',
-            'StageOutSE': stageout_se,
-            'StageOutExitStatus': str(stageout_exit_code),
-            'StageOutExitStatusReason': 'Copy succedeed with srm-lcg utils',
-            'CrabUserCpuTime': str(cputime),
-            'CrabWrapperTime': str(total_time),
-            'WCCPU': str(total_time),
-            'NoEventsPerRun': str(events_per_run),
-            'NbEvPerRun': str(events_per_run),
-            'NEventsProcessed': str(events_per_run)
-            }
+    'ExeTime': str(exe_time),
+    'ExeExitCode': str(exe_exit_code),
+    'JobExitCode': str(task_exit_code),
+    'JobExitReason': '',
+    'StageOutSE': stageout_se,
+    'StageOutExitStatus': str(stageout_exit_code),
+    'StageOutExitStatusReason': 'Copy succedeed with srm-lcg utils',
+    'CrabUserCpuTime': str(cputime),
+    'CrabWrapperTime': str(total_time),
+    'WCCPU': str(total_time),
+    'NoEventsPerRun': str(events_per_run),
+    'NbEvPerRun': str(events_per_run),
+    'NEventsProcessed': str(events_per_run)
+}
 try:
     parameters.update({'CrabCpuPercentage': str(float(cputime)/float(total_time))})
 except:

--- a/lobster/core/source.py
+++ b/lobster/core/source.py
@@ -285,7 +285,7 @@ class TaskProvider(object):
                 Number of cores available.
             tasks : dict
                 Dictionary with category names as keys and the number of
-                tasks in the queu as values.
+                tasks in the queue as values.
         """
         # How many cores we need to occupy: have at least 10% of the
         # available cores provisioned with waiting work

--- a/lobster/core/source.py
+++ b/lobster/core/source.py
@@ -11,7 +11,7 @@ import subprocess
 import work_queue as wq
 import yaml
 
-from collections import defaultdict
+from collections import defaultdict, Counter
 from hashlib import sha1
 
 from lobster import fs, se, util
@@ -485,12 +485,13 @@ class TaskProvider(object):
         propagate = defaultdict(dict)
         input_files = defaultdict(set)
         summary = ReleaseSummary()
+        transfers = defaultdict(lambda: defaultdict(Counter))
 
         for task in tasks:
             self.__dash.update_task(task.tag, dash.DONE)
 
             handler = self.__taskhandlers[task.tag]
-            failed, task_update, file_update, unit_update = handler.process(task, summary)
+            failed, task_update, file_update, unit_update = handler.process(task, summary, transfers)
 
             wflow = getattr(self.config.workflows, handler.dataset)
 
@@ -541,6 +542,9 @@ class TaskProvider(object):
 
         for label, infos in propagate.items():
             self.__store.register_files(infos, label)
+
+        if len(transfers) > 0:
+            self.__store.update_transfers(transfers)
 
     def terminate(self):
         for id in self.__store.running_tasks():

--- a/test/data/handler/successful/report.json
+++ b/test/data/handler/successful/report.json
@@ -59,5 +59,13 @@
   "output size": 15037503, 
   "events written": 4000, 
   "task exit code": 0, 
-  "stageout exit code": 0
+  "stageout exit code": 0,
+  "transfers": {
+    "chirp": {
+      "stageout success": 1
+    },
+    "srm": {
+      "stageout failure": 1
+    }
+  }
 }

--- a/test/test_core_task.py
+++ b/test/test_core_task.py
@@ -1,3 +1,4 @@
+from collections import defaultdict, Counter
 import os
 import unittest
 
@@ -22,7 +23,7 @@ class TestTask(unittest.TestCase):
         summary = ReleaseSummary()
         handler = TaskHandler(1, "test", [], [], [],
                 os.path.join(os.path.dirname(__file__), "data/handler/successful"))
-        failed, task_update, file_update, unit_update = handler.process(DummyTask(), summary)
+        failed, task_update, file_update, unit_update = handler.process(DummyTask(), summary, defaultdict(lambda: defaultdict(Counter)))
         outinfo = handler.output_info
         assert outinfo.lumis == [(1, 261), (1, 262), (1, 263), (1, 264), (1, 265), (1, 266), (1, 267),
                 (1, 268), (1, 269), (1, 270), (1, 271), (1, 272), (1, 273), (1, 274), (1, 275),


### PR DESCRIPTION
This was a little tricky because there are can be different sets of protocols for each task, depending on the user's `StorageConfiguration`. I chose to save json strings to the SQL DB-- it's cramming a square peg in a round hole-- we should use a NoSQL DB to do this properly, or add all possible protocols as columns in the SQL DB. I chose this approach to avoid adding all of the new columns, even though it's a hack. I was worried about performance, so I'm only adding transfer info to the workflows table for now. If we find we need more granularity we can add it to the tasks table later.

I was a little unhappy with the nomenclature here, because I wanted each protocol in the table to map to its prefix for the `StorageConfiguration`, but `root` has two possible actions (xrdcp or streaming). I went with `xrdcp` for xrdcp and `root` for streaming.

I felt that a table was the clearest way to display this data, rather than multiple pie charts (I'm not convinced a pie chart is ever actually clearer than a table.) Output looks like this (stage-in is blank for this test because I am generating events).

![screen shot 2016-05-04 at 3 47 26 pm](https://cloud.githubusercontent.com/assets/5114833/15029086/0b7f28c0-121a-11e6-814e-2df7ff5c2454.png)
