### PR TITLE
Catch `TypeErrors` from Chirp.

### DIFF
--- a/lobster/se.py
+++ b/lobster/se.py
@@ -69,10 +69,11 @@ class StorageElement(object):
                 try:
                     return imp.fixresult(getattr(imp, attr)(*map(imp.lfn2pfn, args), **kwargs))
                 except (IOError, OSError) as e:
-                    logger.debug("method {0} failed with {1}".format(imp, e))
+                    logger.debug("method {0} failed with {1}, using args {2}, {3}".format(imp, e, args, kwargs))
                     lasterror = e
                 except TypeError as e:
-                    logger.debug("chirp binding received an unexpected type; method {0} failed with {1}".format(imp, e))
+                    logger.error("binding received an unexpected type; method {0} failed with {1}, using "
+                        "args {2}, {3}".format(imp, e, args, kwargs))
                     lasterror = e
             raise AttributeError("no resolution found for method '{0}' with arguments '{1}': {2}".format(attr, args, lasterror))
         return switch

--- a/lobster/se.py
+++ b/lobster/se.py
@@ -71,6 +71,9 @@ class StorageElement(object):
                 except (IOError, OSError) as e:
                     logger.debug("method {0} failed with {1}".format(imp, e))
                     lasterror = e
+                except TypeError as e:
+                    logger.debug("chirp binding received an unexpected type; method {0} failed with {1}".format(imp, e))
+                    lasterror = e
             raise AttributeError("no resolution found for method '{0}' with arguments '{1}': {2}".format(attr, args, lasterror))
         return switch
 


### PR DESCRIPTION
This hack addresses #346 so that we don't bring down the master
for this error, but let's leave the issue open until we can
solve it correctly.