### PR TITLE
Allow user to not specify a core guess for WQ allocations.

### DIFF
--- a/lobster/core/workflow.py
+++ b/lobster/core/workflow.py
@@ -64,7 +64,7 @@ class Category(Configurable):
     def __init__(self,
             name,
             mode='max_throughput',
-            cores=1,
+            cores=None,
             memory=None,
             disk=None,
             runtime=None,


### PR DESCRIPTION
Default can be `None` now, though we use 1 in that case
for relevant master calculations. Fixes #356.