### PR TITLE
Re-read stored configuration upon changes.

### DIFF
--- a/docs/run.rst
+++ b/docs/run.rst
@@ -135,11 +135,8 @@ the option ``LIBHDFS_OPTS=-Xmx100m``.
 Changing configuration options
 ------------------------------
 
-Lobster provides a ``configure`` command to change certain mutable
-parameters.  When running, the changes may take a while to show any effect.
-Parameters of the :class:`~lobster.core.config.Config` object may be
-changed with simple python expressions.  Example usage::
-
-    lobster configure "storage.output.append(storage.expand_site('root://T3_US_NotreDame/foo/bar'))" config.py
-    lobster configure "advanced_options.threshold_for_failure += 30"
-    lobster configure categories.io_intense.tasks=40
+Lobster provides a ``configure`` command to change certain configuration
+settings.  The command will open an editor showing the current
+configuration.  Changes will be propagated when the configuration is
+re-read by the Lobster main-loop after saving the file.  This may take a
+few minutes for changes to have an effect

--- a/docs/run.rst
+++ b/docs/run.rst
@@ -139,4 +139,6 @@ Lobster provides a ``configure`` command to change certain configuration
 settings.  The command will open an editor showing the current
 configuration.  Changes will be propagated when the configuration is
 re-read by the Lobster main-loop after saving the file.  This may take a
-few minutes for changes to have an effect
+few minutes for changes to have an effect.
+
+Modifiable attributes are listed in the documentation of each class.

--- a/docs/run.rst
+++ b/docs/run.rst
@@ -135,10 +135,21 @@ the option ``LIBHDFS_OPTS=-Xmx100m``.
 Changing configuration options
 ------------------------------
 
-Lobster provides a ``configure`` command to change certain configuration
-settings.  The command will open an editor showing the current
-configuration.  Changes will be propagated when the configuration is
-re-read by the Lobster main-loop after saving the file.  This may take a
-few minutes for changes to have an effect.
+Lobster copies the initial configuration to its working directory as
+`config.py`.  This configuration can be changed to modify the settings of
+a running Lobster instance.  These changes will be propagated when the
+configuration is re-read by the Lobster main-loop after saving the file.
+This may take a few minutes for changes to have an effect, Lobster show
+logging messages about changes in both the main log and `configure.log` in
+the working directory.
 
-Modifiable attributes are listed in the documentation of each class.
+Only attributes mentioned as modifiable in the documentation of each class
+can be changed.
+
+Lobster also provides a ``configure`` convenience command to edit the
+configuration, which will launch an editor to edit the current
+configuration.
+
+.. note::
+   The ``configure`` command uses the environment variable ``EDITOR`` to
+   determine which editor to use, and uses `vi` as a default.

--- a/lobster/commands/configuration.py
+++ b/lobster/commands/configuration.py
@@ -1,3 +1,6 @@
+import os
+import sys
+
 from lobster.core.command import Command
 
 
@@ -10,4 +13,5 @@ class Configuration(Command):
         pass
 
     def run(self, args):
-        print args.config
+        with open(os.path.join(args.config.workdir, 'config.py')) as fd:
+            sys.stdout.write("".join(fd.readlines()))

--- a/lobster/commands/configure.py
+++ b/lobster/commands/configure.py
@@ -18,7 +18,7 @@ class Configure(Command):
 
         try:
             subprocess.check_call([
-                os.environ.get('EDITOR', os.environ.get('VISUAL', 'vi')),
+                os.environ.get('EDITOR', 'vi'),
                 os.path.join(args.config.workdir, 'config.py')])
             logger.info("check {} to see if changes got propagated (may take a few minutes)".format(
                 os.path.join(args.config.workdir, 'configure.log')))

--- a/lobster/commands/configure.py
+++ b/lobster/commands/configure.py
@@ -1,9 +1,9 @@
 import logging
 import os
+import subprocess
 
 from lobster import util
 from lobster.core.command import Command
-from lockfile import AlreadyLocked
 
 class Configure(Command):
     @property
@@ -11,23 +11,16 @@ class Configure(Command):
         return 'change the configuration of a running lobster process'
 
     def setup(self, argparser):
-        argparser.add_argument('command', help='a python expression to change a mutable configuration setting')
+        pass
 
     def run(self, args):
         logger = logging.getLogger('lobster.configure')
 
         try:
-            pidfile = util.get_lock(args.config.workdir)
-            logger.info("Lobster process not running, directly changing configuration.")
-            with util.PartiallyMutable.lockdown():
-                exec args.command in {'config': args.config, 'storage': args.config.storage}, {}
-                args.config.save()
-        except AlreadyLocked:
-            logger.info("Lobster process still running, contacting process...")
-            logger.info("sending command: " + args.command)
-            logger.info("check the log of the main process for success")
-
-            icp = open(os.path.join(args.config.workdir, 'ipc'), 'w')
-            icp.write(args.command + '\n')
+            subprocess.check_call([
+                os.environ.get('EDITOR', os.environ.get('VISUAL', 'vi')),
+                os.path.join(args.config.workdir, 'config.py')])
+            logger.info("check {} to see if changes got propagated (may take a few minutes)".format(
+                os.path.join(args.config.workdir, 'configure.log')))
         except Exception as e:
-            logger.error("can't change values: {}".format(e))
+            logger.error("error editing current configuration: {}".format(e))

--- a/lobster/commands/plot.py
+++ b/lobster/commands/plot.py
@@ -1083,9 +1083,7 @@ class Plotter(object):
 
         jsons = self.savejsons(units_processed)
 
-        with open(os.path.join(self.__plotdir, 'config.py'), 'w') as fd:
-            fd.write(str(self.config))
-
+        shutil.copy(os.path.join(self.config.workdir, 'config.py'), os.path.join(self.__plotdir, 'config.py'))
         for fn in ['styles.css', 'gh.png']:
             shutil.copy(os.path.join(os.path.dirname(__file__), 'data', fn),
                     os.path.join(self.__plotdir, fn))

--- a/lobster/commands/process.py
+++ b/lobster/commands/process.py
@@ -176,7 +176,8 @@ class Process(Command):
                 pass
 
     def sprint(self):
-        task_src = TaskProvider(self.config)
+        with util.PartiallyMutable.unlock():
+            task_src = TaskProvider(self.config)
         action = actions.Actions(self.config, task_src)
         from WMCore.Credential.Proxy import Proxy
         proxy = Proxy({'logger': logging.getLogger("WMCore")})

--- a/lobster/commands/process.py
+++ b/lobster/commands/process.py
@@ -157,7 +157,7 @@ class Process(Command):
                 detach_process=not args.foreground,
                 stdout=sys.stdout if args.foreground else ttyfile,
                 stderr=sys.stderr if args.foreground else ttyfile,
-                files_preserve=[args.preserve],
+                files_preserve=args.preserve,
                 working_directory=self.config.workdir,
                 pidfile=util.get_lock(self.config.workdir, args.force),
                 prevent_core=False,

--- a/lobster/commands/process.py
+++ b/lobster/commands/process.py
@@ -100,8 +100,6 @@ class Process(Command):
     def setup(self, argparser):
         argparser.add_argument('--finalize', action='store_true', default=False,
                 help='do not process any additional data; wrap project up by merging everything')
-        argparser.add_argument('--increase-thresholds', const=10, nargs='?', type=int,
-                help='increase failure/skipping thresholds')
         argparser.add_argument('--foreground', action='store_true', default=False,
                 help='do not daemonize; run in the foreground instead')
         argparser.add_argument('-f', '--force', action='store_true', default=False,
@@ -113,10 +111,6 @@ class Process(Command):
         if args.finalize:
             args.config.advanced.threshold_for_failure = 0
             args.config.advanced.threshold_for_skipping = 0
-        if args.increase_thresholds:
-            args.config.advanced.threshold_for_failure += args.increase_thresholds
-            args.config.advanced.threshold_for_skipping += args.increase_thresholds
-            args.config.save()
 
         if not os.path.exists(self.config.workdir):
             os.makedirs(self.config.workdir)

--- a/lobster/commands/process.py
+++ b/lobster/commands/process.py
@@ -63,6 +63,9 @@ class Process(Command):
     def daemonizable(self):
         return True
 
+    def additional_logs(self):
+        return ['configure']
+
     def setup_logging(self, category):
         filename = os.path.join(self.config.workdir, "lobster_stats_{}.log".format(category))
         if not hasattr(self, 'log_attributes'):

--- a/lobster/core/command.py
+++ b/lobster/core/command.py
@@ -33,6 +33,9 @@ class Command(object):
     def daemonizable(self):
         return False
 
+    def additional_logs(self):
+        return []
+
     @abstractmethod
     def setup(self, argparser):
         pass

--- a/lobster/core/config.py
+++ b/lobster/core/config.py
@@ -30,6 +30,9 @@ class Items(object):
     def __len__(self):
         return len(self.__sequence)
 
+    def __getitem__(self, n):
+        return self.__sequence[n]
+
     def __repr__(self):
         if len(self.__sequence) == 0:
             return '[]'
@@ -74,8 +77,7 @@ class Config(Configurable):
 
     _mutable = {}
 
-    def __init__(self, label, workdir, storage, workflows, advanced=None, plotdir=None,
-            foremen_logs=None,
+    def __init__(self, label, workdir, storage, workflows, advanced=None, plotdir=None, foremen_logs=None,
             base_directory=None, base_configuration=None, startup_directory=None):
         """
         Top-level configuration object for Lobster

--- a/lobster/core/config.py
+++ b/lobster/core/config.py
@@ -127,6 +127,12 @@ class AdvancedOptions(Configurable):
     """
     Advanced options for tuning Lobster
 
+    Attributes modifiable at runtime:
+
+    * `payload`
+    * `threshold_for_failure`
+    * `threshold_for_skipping`
+
     Parameters
     ----------
         use_dashboard : bool

--- a/lobster/core/config.py
+++ b/lobster/core/config.py
@@ -170,9 +170,9 @@ class AdvancedOptions(Configurable):
     """
 
     _mutable = {
-            'payload': (None, None, tuple()),
-            'threshold_for_failure': ('source', 'update_paused', tuple()),
-            'threshold_for_skipping': ('source', 'update_paused', tuple())
+            'payload': (None, [], False),
+            'threshold_for_failure': ('source.update_paused', [], False),
+            'threshold_for_skipping': ('source.update_paused', [], False)
     }
 
     def __init__(self,

--- a/lobster/core/source.py
+++ b/lobster/core/source.py
@@ -577,6 +577,16 @@ class TaskProvider(object):
         """
         self.__store.update_workflow_stats_paused()
 
+    def update_runtime(self, category):
+        """Update the runtime for all workflows with the corresponding
+        category.
+        """
+        update = []
+        for wflow in self.config.workflows:
+            if wflow.category == category:
+                update.append((category.runtime, wflow.label))
+        self.__store.update_workflow_runtime(update)
+
     def tasks_left(self):
         return self.__store.estimate_tasks_left()
 

--- a/lobster/core/source.py
+++ b/lobster/core/source.py
@@ -150,6 +150,7 @@ class TaskProvider(object):
                 self.config.label,
                 sha1(str(datetime.datetime.utcnow())).hexdigest()[-16:])
             util.register_checkpoint(self.workdir, 'id', self.taskid)
+            shutil.copy(self.config.base_configuration, os.path.join(self.workdir, 'config.py'))
         else:
             self.taskid = util.checkpoint(self.workdir, 'id')
             util.register_checkpoint(self.workdir, 'RESTARTED', str(datetime.datetime.utcnow()))

--- a/lobster/core/unit.py
+++ b/lobster/core/unit.py
@@ -564,6 +564,15 @@ class UnitStore:
             elif len(r.dependents) > 0:
                 self.update_workflow_stats(r.dependents)
 
+    def update_workflow_runtime(self, updates):
+        """Update workflow runtimes in the database.
+
+        To synchronize runtimes present in the configuration with the ones
+        in the database used for task size calculations.
+        """
+        with self.db:
+            self.db.executemany("update workflows set taskruntime=? where label=?", updates)
+
     def update_workflow_stats(self, label):
         id, size, targettime = self.db.execute("select id, tasksize, taskruntime from workflows where label=?", (label,)).fetchone()
 

--- a/lobster/core/workflow.py
+++ b/lobster/core/workflow.py
@@ -25,6 +25,11 @@ class Category(Configurable):
     terminate tasks of :class:`.Workflow` in the group that exceed the
     specified resources.
 
+    Attributs modifiable at runtime:
+
+    * `tasks`
+    * `runtime`
+
     Parameters
     ----------
         name : str

--- a/lobster/core/workflow.py
+++ b/lobster/core/workflow.py
@@ -58,7 +58,8 @@ class Category(Configurable):
             the same time.
     """
     _mutable = {
-            'tasks': (None, None, tuple())
+            'tasks': (None, [], False),
+            'runtime': ('source.update_runtime', [], True)
     }
 
     def __init__(self,

--- a/lobster/se.py
+++ b/lobster/se.py
@@ -345,6 +345,11 @@ class StorageConfiguration(Configurable):
 
     The `chirp` protocol requires an instance of a `Chirp` server.
 
+    Attributes modifiable at runtime:
+
+    * `input`
+    * `output`
+
     Parameters
     ----------
         output : list

--- a/lobster/se.py
+++ b/lobster/se.py
@@ -372,8 +372,8 @@ class StorageConfiguration(Configurable):
             URLs will be attempted for all input files.
     """
     _mutable = {
-            'input': (None, None, tuple()),
-            'output': (None, None, tuple())
+            'input': (None, [], False),
+            'output': (None, [], False)
     }
 
     # Map protocol shorthands to actual protocol names

--- a/lobster/se.py
+++ b/lobster/se.py
@@ -404,8 +404,8 @@ class StorageConfiguration(Configurable):
         self.use_work_queue_for_inputs = use_work_queue_for_inputs
         self.use_work_queue_for_outputs = use_work_queue_for_outputs
 
-        self.__shuffle_inputs = shuffle_inputs
-        self.__shuffle_outputs = shuffle_outputs
+        self.shuffle_inputs = shuffle_inputs
+        self.shuffle_outputs = shuffle_outputs
 
         self.disable_input_streaming = disable_input_streaming
         self.disable_stage_in_acceleration = disable_stage_in_acceleration
@@ -522,9 +522,9 @@ class StorageConfiguration(Configurable):
         merge : bool
             Specify if this is a merging parameter set.
         """
-        if self.__shuffle_inputs:
+        if self.shuffle_inputs:
             random.shuffle(self.input)
-        if self.__shuffle_outputs or (self.__shuffle_inputs and merge):
+        if self.shuffle_outputs or (self.shuffle_inputs and merge):
             random.shuffle(self.output)
 
         parameters['input'] = self.input if not merge else self.output

--- a/lobster/ui.py
+++ b/lobster/ui.py
@@ -58,6 +58,7 @@ def boil():
         parser.error("the working directory or configuration '{0}' does not exist".format(args.checkpoint))
 
     args.config = cfg
+    args.preserve = []
 
     # Handle logging for everything in only one place!
     level = max(1, args.config.advanced.log_level + args.quiet - args.verbose) * 10
@@ -76,7 +77,7 @@ def boil():
             os.makedirs(cfg.workdir)
         fileh = logging.handlers.RotatingFileHandler(os.path.join(cfg.workdir, fn), maxBytes=500e6, backupCount=10)
         fileh.setFormatter(formatter)
-        args.preserve = fileh.stream
+        args.preserve.append(fileh.stream)
         logger.addHandler(fileh)
 
         if not getattr(args, "foreground", False):
@@ -90,6 +91,7 @@ def boil():
             os.makedirs(cfg.workdir)
         fileh = logging.handlers.RotatingFileHandler(os.path.join(cfg.workdir, fn), maxBytes=500e6, backupCount=10)
         fileh.setFormatter(formatter)
+        args.preserve.append(fileh.stream)
         l.addHandler(fileh)
 
     args.plugin.run(args)

--- a/lobster/ui.py
+++ b/lobster/ui.py
@@ -42,9 +42,10 @@ def boil():
             cfg = config.Config.load(cfg.workdir)
         else:
             # This is the original configuration file!
-            cfg.base_directory = os.path.abspath(os.path.dirname(args.checkpoint))
-            cfg.base_configuration = os.path.abspath(args.checkpoint)
-            cfg.startup_directory = os.path.abspath(os.getcwd())
+            with util.PartiallyMutable.unlock():
+                cfg.base_directory = os.path.abspath(os.path.dirname(args.checkpoint))
+                cfg.base_configuration = os.path.abspath(args.checkpoint)
+                cfg.startup_directory = os.path.abspath(os.getcwd())
     elif os.path.isdir(args.checkpoint):
         # Load configuration from working directory passed to us
         workdir = args.checkpoint

--- a/lobster/ui.py
+++ b/lobster/ui.py
@@ -81,4 +81,14 @@ def boil():
         if not getattr(args, "foreground", False):
             logger.removeHandler(console)
 
+    for p in args.plugin.additional_logs():
+        fn = p + '.log'
+        l = logging.getLogger('lobster.' + p)
+        logger.info("saving additional log for {1} to {0}".format(os.path.join(cfg.workdir, fn), p))
+        if not os.path.isdir(cfg.workdir):
+            os.makedirs(cfg.workdir)
+        fileh = logging.handlers.RotatingFileHandler(os.path.join(cfg.workdir, fn), maxBytes=500e6, backupCount=10)
+        fileh.setFormatter(formatter)
+        l.addHandler(fileh)
+
     args.plugin.run(args)

--- a/test/test_core_dataset.py
+++ b/test/test_core_dataset.py
@@ -4,7 +4,7 @@ import tempfile
 import unittest
 
 from lobster.core import Dataset
-from lobster import fs, se
+from lobster import fs, se, util
 
 class TestDataset(unittest.TestCase):
     @classmethod
@@ -30,15 +30,16 @@ class TestDataset(unittest.TestCase):
         shutil.rmtree(cls.workdir)
 
     def runTest(self):
-        s = se.StorageConfiguration(output=[], input=['file://' + self.workdir])
-        s.activate()
+        with util.PartiallyMutable.unlock():
+            s = se.StorageConfiguration(output=[], input=['file://' + self.workdir])
+            s.activate()
 
-        with fs.default():
-            info = Dataset(files='eggs').get_info()
-            assert len(info.files) == 10
+            with fs.default():
+                info = Dataset(files='eggs').get_info()
+                assert len(info.files) == 10
 
-            info = Dataset(files=['eggs', 'ham']).get_info()
-            assert len(info.files) == 15
+                info = Dataset(files=['eggs', 'ham']).get_info()
+                assert len(info.files) == 15
 
-            info = Dataset(files='eggs/1.txt').get_info()
-            assert len(info.files) == 1
+                info = Dataset(files='eggs/1.txt').get_info()
+                assert len(info.files) == 1

--- a/test/test_se.py
+++ b/test/test_se.py
@@ -1,6 +1,6 @@
 # vim: foldmethod=marker
 from lobster.core import dataset
-from lobster import fs, se
+from lobster import fs, se, util
 import os
 import random
 import shutil
@@ -33,10 +33,11 @@ class TestSE(unittest.TestCase):
         s = se.StorageConfiguration(output=[], input=url)
         s.activate()
 
-        with fs.default():
-            ds = dataset.Dataset(files='spam/')
-            info = ds.get_info()
-            assert len(info.files) == 10
+        with util.PartiallyMutable.unlock():
+            with fs.default():
+                ds = dataset.Dataset(files='spam/')
+                info = ds.get_info()
+                assert len(info.files) == 10
 
     def permissions(self, url):
         if not isinstance(url, list):


### PR DESCRIPTION
Does away with the current implementation of the configure command, and swaps it out by editing a saved configuration that is synced with the pickled once changes are detected (via the modification time).

Other changes:

* plotting now displays the original configuration
* category runtime is now modifiable
* separate output log for configuration changes
* removed arguments to increase thresholds, as that's better done by changing the configuration directly without a restart