### PR TITLE
Move sandbox to a class

### DIFF
--- a/examples/mc_gen.py
+++ b/examples/mc_gen.py
@@ -18,7 +18,7 @@ workflows = []
 lhe = Workflow(
         label='lhe_step',
         pset='mc_gen/HIG-RunIIWinter15wmLHE-00196_1_cfg.py',
-        sandbox_release='mc_gen/CMSSW_7_1_16_patch1',
+        sandbox=cmssw.Sandbox(release='mc_gen/CMSSW_7_1_16_patch1'),
         merge_size='125M',
         dataset=ProductionDataset(
             events_per_task=250,
@@ -35,7 +35,7 @@ lhe = Workflow(
 gs = Workflow(
         label='gs_step',
         pset='mc_gen/HIG-RunIISummer15GS-00177_1_cfg.py',
-        sandbox_release='mc_gen/CMSSW_7_1_18',
+        sandbox=cmssw.Sandbox(release='mc_gen/CMSSW_7_1_18'),
         merge_size='500M',
         dataset=ParentDataset(
             parent=lhe,
@@ -52,7 +52,7 @@ gs = Workflow(
 digi = Workflow(
         label='digi_step',
         pset='mc_gen/HIG-RunIIFall15DR76-00243_1_cfg.py',
-        sandbox_release='mc_gen/CMSSW_7_6_1',
+        sandbox=cmssw.Sandbox(release='mc_gen/CMSSW_7_6_1'),
         merge_size='1G',
         dataset=ParentDataset(
             parent=gs,
@@ -69,7 +69,7 @@ digi = Workflow(
 reco = Workflow(
         label='reco_step',
         pset='mc_gen/HIG-RunIIFall15DR76-00243_2_cfg.py',
-        sandbox_release='mc_gen/CMSSW_7_6_1',
+        sandbox=cmssw.Sandbox(release='mc_gen/CMSSW_7_6_1'),
         # Explicitly specify outputs, since the dependency processing only
         # works for workflows with one output file, but the configuration
         # includes two.
@@ -90,7 +90,7 @@ reco = Workflow(
 maod = Workflow(
         label='mAOD_step',
         pset='mc_gen/HIG-RunIIFall15MiniAODv2-00224_1_cfg.py',
-        sandbox_release='mc_gen/CMSSW_7_6_3',
+        sandbox=cmssw.Sandbox(release='mc_gen/CMSSW_7_6_3'),
         merge_size='500M',
         dataset=ParentDataset(
             parent=reco,

--- a/lobster/cmssw/__init__.py
+++ b/lobster/cmssw/__init__.py
@@ -1,2 +1,3 @@
 import dash
 from dataset import Dataset
+from sandbox import Sandbox

--- a/lobster/cmssw/sandbox.py
+++ b/lobster/cmssw/sandbox.py
@@ -5,80 +5,108 @@ import os
 import shutil
 import tarfile
 
-__all__ = ['package']
+import lobster.core
+import lobster.util
+
+__all__ = ['Sandbox']
 
 logger = logging.getLogger('lobster.sandbox')
 cache = {}
 
-def release2filename(rel):
-    """Returns a filename for a given release top, i.e., the file system
-    path of a release.
+
+class Sandbox(lobster.core.Sandbox):
+
     """
-    p = os.path.abspath(os.path.expandvars(os.path.expanduser(rel)))
-    v = os.path.split(p)[1]
-    return "sandbox-{v}-{d}.tar.bz2".format(v=v, d=hashlib.sha1(p).hexdigest()[:7])
+    Packs a sandbox to run CMSSW out of.
 
-def dontpack(fn):
-    res = ('/.' in fn and not '/.SCRAM' in fn) or '/CVS/' in fn
-    if res:
-        return True
-    return False
+    By default, all necessary directories, plus any `python` or `data`
+    directories to be found under `src` are included.
 
-def recycle(fn, outdir):
-    shutil.copy2(fn, outdir)
-    for file in tarfile.open(fn):
-        if ".SCRAM" in file.name:
-            rtname = os.path.dirname(os.path.normpath(file.name)).split("/")[0]
-            break
-    return rtname, os.path.join(outdir, os.path.split(fn)[-1])
+    Parameters
+    ----------
+        include : list
+            Directories or files to include, relative to the `src`
+            directory of the release used.
+        release : str
+            The path to the CMSSW release to be used as a sandbox.
+            Defaults to the environment variable `LOCALRT`.
+    """
 
-def package(indir, outdir, blacklist=None):
-    if blacklist is None:
-        blacklist = []
+    _mutable = {}
 
-    rtname = os.path.split(os.path.normpath(indir))[1]
-    outfile = os.path.join(outdir, release2filename(indir))
+    def __init__(self, include=None, release=None, blacklist=None):
+        super(Sandbox, self).__init__(blacklist)
+        try:
+            self.release = release or os.environ['LOCALRT']
+        except KeyError:
+            raise AttributeError("Need to be either in a `cmsenv` or specify a sandbox release!")
+        self.include = include or []
 
-    if os.path.exists(outfile):
-        logger.info("reusing sandbox in {0}".format(outfile))
-        return rtname, outfile
+    def __release2filename(self, rel):
+        """Returns a filename for a given release top, i.e., the file system
+        path of a release.
+        """
+        p = os.path.abspath(os.path.expandvars(os.path.expanduser(rel)))
+        v = os.path.split(p)[1]
+        return "sandbox-{v}-{d}.tar.bz2".format(v=v, d=hashlib.sha1(p).hexdigest()[:7])
 
-    def ignore_file(fn):
-        for test in blacklist:
-            if fnmatch.fnmatch(os.path.split(fn)[1], test):
-                return True
+    def __dontpack(self, fn):
+        res = ('/.' in fn and '/.SCRAM' not in fn) or '/CVS/' in fn
+        if res:
+            return True
         return False
 
-    logger.info("packing sandbox into {0}".format(outfile))
-    logger.debug("using release name {1} with base directory {0}".format(indir, rtname))
-    tarball = tarfile.open(outfile, "w|bz2")
+    def _recycle(self, outdir):
+        shutil.copy2(self._recycle, outdir)
+        for file in tarfile.open(self._recycle):
+            if ".SCRAM" in file.name:
+                rtname = os.path.dirname(os.path.normpath(file.name)).split("/")[0]
+                break
+        return rtname, os.path.join(outdir, os.path.split(self._recycle)[-1])
 
-    # package bin, etc
-    subdirs = ['.SCRAM', 'bin', 'cfipython', 'config', 'lib', 'module', 'python']
+    def _package(self, basedirs, outdir):
+        indir = lobster.util.findpath(basedirs, self.release)
+        rtname = os.path.split(os.path.normpath(indir))[1]
+        outfile = os.path.join(outdir, self.__release2filename(indir))
 
-    for (path, dirs, files) in os.walk(os.path.join(indir, 'src')):
-        if any(d in blacklist for d in dirs):
-            continue
+        if os.path.exists(outfile):
+            logger.info("reusing sandbox in {0}".format(outfile))
+            return rtname, outfile
 
-        for subdir in ['data', 'python']:
-            if subdir in dirs:
-                rtpath = os.path.join(os.path.relpath(path, indir), subdir)
-                subdirs.append(rtpath)
+        def ignore_file(fn):
+            for test in self.blacklist:
+                if fnmatch.fnmatch(os.path.split(fn)[1], test):
+                    return True
+            return False
 
-    for subdir in subdirs:
-        if isinstance(subdir, tuple) or isinstance(subdir, list):
-            (subdir, sandboxname) = subdir
-        else:
-            sandboxname = subdir
-        inname = os.path.join(indir, subdir)
-        if not os.path.exists(inname):
-            continue
+        logger.info("packing sandbox into {0}".format(outfile))
+        logger.debug("using release name {1} with base directory {0}".format(indir, rtname))
+        tarball = tarfile.open(outfile, "w|bz2")
 
-        outname = os.path.join(rtname, sandboxname)
-        logger.debug("packing {0}".format(subdir))
+        # package bin, etc
+        subdirs = ['.SCRAM', 'bin', 'cfipython', 'config', 'lib', 'module', 'python']
+        subdirs += [os.path.join('src', incl) for incl in self.include]
 
-        tarball.add(inname, outname, exclude=ignore_file)
+        for (path, dirs, files) in os.walk(os.path.join(indir, 'src')):
+            for subdir in ['data', 'python']:
+                if subdir in dirs:
+                    rtpath = os.path.join(os.path.relpath(path, indir), subdir)
+                    subdirs.append(rtpath)
 
-    tarball.close()
+        for subdir in subdirs:
+            if isinstance(subdir, tuple) or isinstance(subdir, list):
+                (subdir, sandboxname) = subdir
+            else:
+                sandboxname = subdir
+            inname = os.path.join(indir, subdir)
+            if not os.path.exists(inname):
+                continue
 
-    return rtname, outfile
+            outname = os.path.join(rtname, sandboxname)
+            logger.debug("packing {0}".format(subdir))
+
+            tarball.add(inname, outname, exclude=ignore_file)
+
+        tarball.close()
+
+        return rtname, outfile

--- a/lobster/core/__init__.py
+++ b/lobster/core/__init__.py
@@ -1,8 +1,9 @@
 from config import AdvancedOptions, Config
 from create import Algo
+from sandbox import Sandbox
 from task import *
 from workflow import Category, Workflow
 from dataset import *
 from lobster.se import StorageConfiguration
 
-__all__ = ['Config', 'AdvancedOptions', 'Category', 'Workflow', 'Dataset', 'ParentDataset', 'ProductionDataset', 'StorageConfiguration']
+__all__ = ['Config', 'AdvancedOptions', 'Category', 'Workflow', 'Dataset', 'ParentDataset', 'ProductionDataset', 'Sandbox', 'StorageConfiguration']

--- a/lobster/core/sandbox.py
+++ b/lobster/core/sandbox.py
@@ -1,0 +1,30 @@
+from lobster.util import Configurable
+
+
+class Sandbox(Configurable):
+
+    """
+    Parameters
+    ----------
+        recycle : str
+            A path to an existing sandbox to re-use.
+        blacklist : list
+            A specification of paths to not pack into the sandbox.
+    """
+
+    _mutable = {}
+
+    def __init__(self, recycle=None, blacklist=None):
+        self.blacklist = blacklist or []
+        self.recycle = recycle
+
+    def package(self, basedirs, outdir):
+        if self.recycle is not None:
+            return self._recycle(outdir)
+        return self._package(basedirs, outdir)
+
+    def _package(self, basedirs, outdir):
+        pass
+
+    def _recycle(self, outdir):
+        pass

--- a/lobster/core/workflow.py
+++ b/lobster/core/workflow.py
@@ -139,8 +139,9 @@ class Workflow(Configurable):
             Activates output file merging when set.  Accepts the suffixes
             *k*, *m*, *g* for kilobyte, megabyte, …
         sandbox : Sandbox
-            Path to a sandbox to re-use.  This sandbox will be copied over
-            to the current working directory.
+            The sandbox to use.  Currently can be either a
+            :class:`~lobster.cmssw.Sandbox` or a
+            :class:`~lobster.core.Sandbox`.
         command : str
             Which executable to run (for non-CMSSW workflows)
         extra_inputs : list
@@ -152,8 +153,6 @@ class Workflow(Configurable):
             A list of arguments.  Each element of the dataset is processed
             once for each argument in this list.  The unique argument is
             also passed to the executable.
-
-            TODO: should really be in the dataset specification
         outputs : list
             A list of strings which specifies the files produced by the
             workflow.  Will be automatically determined for CMSSW

--- a/lobster/core/workflow.py
+++ b/lobster/core/workflow.py
@@ -7,7 +7,6 @@ import shutil
 import sys
 
 from lobster import fs, util
-from lobster.cmssw import sandbox
 from lobster.core.dataset import ParentDataset, ProductionDataset
 from lobster.core.task import *
 from lobster.util import Configurable
@@ -139,14 +138,9 @@ class Workflow(Configurable):
         merge_size : str
             Activates output file merging when set.  Accepts the suffixes
             *k*, *m*, *g* for kilobyte, megabyte, …
-        sandbox : str
+        sandbox : Sandbox
             Path to a sandbox to re-use.  This sandbox will be copied over
             to the current working directory.
-        sandbox_release : str
-            The path to the CMSSW release to be used as a sandbox.
-            Defaults to the environment variable `LOCALRT`.
-        sandbox_blacklist : list
-            A specification of paths to not pack into the sandbox.
         command : str
             Which executable to run (for non-CMSSW workflows)
         extra_inputs : list
@@ -193,8 +187,6 @@ class Workflow(Configurable):
             cleanup_input=False,
             merge_size=-1,
             sandbox=None,
-            sandbox_release=None,
-            sandbox_blacklist=None,
             command='cmsRun',
             extra_inputs=None,
             arguments=None,
@@ -241,15 +233,8 @@ class Workflow(Configurable):
         self.local = local or hasattr(dataset, 'files')
         self.edm_output = edm_output
 
-        self.sandbox = sandbox
-        if sandbox_release is not None:
-            self.sandbox_release = sandbox_release
-        else:
-            try:
-                self.sandbox_release = os.environ['LOCALRT']
-            except:
-                raise AttributeError("Need to be either in a `cmsenv` or specify a sandbox release!")
-        self.sandbox_blacklist = sandbox_blacklist
+        from lobster.cmssw.sandbox import Sandbox
+        self.sandbox = sandbox or Sandbox()
 
     def __repr__(self):
         override = {'category': 'category_' + self.category.name}
@@ -336,9 +321,6 @@ class Workflow(Configurable):
         """Determine output files for CMSSW tasks.
         """
         self.outputs = []
-        # Save determined outputs to the configuration in the
-        # working directory.
-        update_config = True
 
         # To avoid problems loading configs that use the VarParsing module
         sys.argv = [os.path.basename(self.pset)] + self.arguments
@@ -358,13 +340,7 @@ class Workflow(Configurable):
     def setup(self, workdir, basedirs):
         self.workdir = os.path.join(workdir, self.label)
 
-        if self.sandbox:
-            self.version, self.sandbox = sandbox.recycle(self.sandbox, workdir)
-        else:
-            self.version, self.sandbox = sandbox.package(
-                    util.findpath(basedirs, self.sandbox_release),
-                    workdir,
-                    self.sandbox_blacklist)
+        self.version, self.sandbox = self.sandbox.package(basedirs, workdir)
 
         self.copy_inputs(basedirs)
         if self.pset and not self.outputs:

--- a/test/data/sandbox/CMSSW_1_2_3/.SCRAM/Environment
+++ b/test/data/sandbox/CMSSW_1_2_3/.SCRAM/Environment
@@ -1,0 +1,1 @@
+Useless.

--- a/test/data/sandbox/CMSSW_1_2_3/src/Foo/mydir/myfile
+++ b/test/data/sandbox/CMSSW_1_2_3/src/Foo/mydir/myfile
@@ -1,0 +1,1 @@
+Spam, ham, eggs!

--- a/test/test_cms_backend.py
+++ b/test/test_cms_backend.py
@@ -55,7 +55,7 @@ class TestSQLBackend(object):
         info.total_units = len(info.files.keys())
         info.path = ''
 
-        return Workflow(label, None, sandbox_release=''), info
+        return Workflow(label, None, sandbox=cmssw.Sandbox(release='')), info
 
     def create_dbs_dataset(self, label, lumi_events=100, lumis=14, filesize=3.5, tasksize=5):
         # {{{
@@ -103,7 +103,7 @@ class TestSQLBackend(object):
 
         info.total_units = sum([len(finfo.lumis) for f, finfo in info.files.items()])
 
-        return Workflow(label, None, sandbox_release=''), info
+        return Workflow(label, None, sandbox=cmssw.Sandbox(release='')), info
         # }}}
 
     def test_create_datasets(self):

--- a/test/test_cms_backend.py
+++ b/test/test_cms_backend.py
@@ -30,6 +30,7 @@ class TestSQLBackend(object):
 
     @classmethod
     def setup_class(cls):
+        os.environ['LOCALRT'] = ''
         cls.workdir = tempfile.mkdtemp()
         cls.interface = UnitStore(
             Config(
@@ -55,7 +56,7 @@ class TestSQLBackend(object):
         info.total_units = len(info.files.keys())
         info.path = ''
 
-        return Workflow(label, None, sandbox=cmssw.Sandbox(release='')), info
+        return Workflow(label, None), info
 
     def create_dbs_dataset(self, label, lumi_events=100, lumis=14, filesize=3.5, tasksize=5):
         # {{{
@@ -103,7 +104,7 @@ class TestSQLBackend(object):
 
         info.total_units = sum([len(finfo.lumis) for f, finfo in info.files.items()])
 
-        return Workflow(label, None, sandbox=cmssw.Sandbox(release='')), info
+        return Workflow(label, None), info
         # }}}
 
     def test_create_datasets(self):

--- a/test/test_cmssw_sandbox.py
+++ b/test/test_cmssw_sandbox.py
@@ -1,0 +1,33 @@
+import os
+import shutil
+import tarfile
+import tempfile
+import unittest
+
+import lobster.cmssw.sandbox
+
+
+class TestSandbox(unittest.TestCase):
+
+    def setUp(self):
+        self.workdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.workdir)
+
+    def test_localrt(self):
+        os.environ['LOCALRT'] = 'data/sandbox/CMSSW_1_2_3'
+        sandbox = lobster.cmssw.sandbox.Sandbox()
+        version, box = sandbox.package([os.path.dirname(__file__)], self.workdir)
+        assert version == 'CMSSW_1_2_3'
+
+    def test_version(self):
+        sandbox = lobster.cmssw.sandbox.Sandbox(release='data/sandbox/CMSSW_1_2_3')
+        version, box = sandbox.package([os.path.dirname(__file__)], self.workdir)
+        assert version == 'CMSSW_1_2_3'
+
+    def test_include(self):
+        sandbox = lobster.cmssw.sandbox.Sandbox(release='data/sandbox/CMSSW_1_2_3', include=['Foo/mydir'])
+        version, box = sandbox.package([os.path.dirname(__file__)], self.workdir)
+        files = [f.name for f in tarfile.open(box)]
+        assert 'CMSSW_1_2_3/src/Foo/mydir' in files


### PR DESCRIPTION
Keeps the number of workflow parameters down a bit, and also allows to easily create a basic sandbox for custom usage/non-standard CMSSW usage.

Next step: move more contents of the `cmssw.Sandbox._package` method to the parent.