### PR TITLE
Improve validation

### DIFF
--- a/examples/simple.py
+++ b/examples/simple.py
@@ -26,10 +26,10 @@ processing = Category(
 
 workflows = []
 
-single_mu = Workflow(
-    label='single_mu',
+ttH = Workflow(
+    label='ttH',
     dataset=cmssw.Dataset(
-        dataset='/SingleMu/Run2012A-recover-06Aug2012-v1/AOD',
+        dataset='/ttHToNonbb_M125_13TeV_powheg_pythia8/RunIISpring15DR74-Asympt25ns_MCRUN2_74_V9-v2/MINIAODSIM',
         events_per_task=5000
     ),
     category=processing,
@@ -39,7 +39,7 @@ single_mu = Workflow(
     outputs=['output.root']
 )
 
-workflows.append(single_mu)
+workflows.append(ttH)
 
 config = Config(
     workdir='/tmpscratch/users/$USER/lobster_test_' + version,

--- a/test/count_events.py
+++ b/test/count_events.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+import argparse
+import glob
+import itertools
+import numpy as np
+import os
+
+parser = argparse.ArgumentParser(description='count unique events in directories of edm files')
+parser.add_argument('paths', nargs='+', help='directories to analyze')
+parser.add_argument('--max', type=int, default=5000000, help='max events to analyze')
+parser.add_argument('--verbose', action='store_true', help='print progress')
+args = parser.parse_args()
+
+import DataFormats.FWLite
+
+events = {}
+for path in args.paths:
+    files = glob.glob('{}/*.root'.format(path))
+
+    events[path] = np.zeros(args.max, dtype='int32, int32, int32')
+    for index, event in enumerate(DataFormats.FWLite.Events(files)):
+        r = event.object().id().run()
+        l = event.object().id().luminosityBlock()
+        e = event.object().id().event()
+
+        events[path][index] = (r, l, e)
+
+        if args.verbose and index % 5000 == 0:
+            print '>>>> entry run lumi event: {:10} {:10} {:10} {:10}'.format(index, r, l, e)
+
+        if index > args.max:
+            break
+
+    unique = len(np.unique(events[path])) - 1
+
+    print 'found {} ({} unique) run, lumi, event sets in {} files in path {}'.format(index + 1, unique, len(files), path)
+
+if len(args.paths) > 1:
+    for first, second in itertools.permutations(args.paths, 2):
+        diff = np.setdiff1d(events[first], events[second])
+        print 'path {} has {} events which are not in {}'.format(first, len(diff), second)

--- a/test/count_events.py
+++ b/test/count_events.py
@@ -28,7 +28,7 @@ for path in args.paths:
         if args.verbose and index % 5000 == 0:
             print '>>>> entry run lumi event: {:10} {:10} {:10} {:10}'.format(index, r, l, e)
 
-        if index > args.max:
+        if index == args.max:
             break
 
     unique = len(np.unique(events[path])) - 1


### PR DESCRIPTION
I think it makes sense to have something we can use to compare two runs and validate that we got the same output events. This is not very fast, but it'll do in a pinch, and we can speed it up later if it proves useful. The fastest way I know how to do this would be with `root_numpy` but I don't think it's worth the added dependency. Sample output:

```
[earth] ~/lobster/test >python count_events.py sample-a sample-b
found 19952 (9976 unique) run, lumi, event sets in 2 files in path sample-a
found 11074 (11074 unique) run, lumi, event sets in 2 files in path sample-b
path sample-a has 0 events which are not in sample-b
path sample-b has 1098 events which are not in sample-a
```

Along with previous improvements, fixes #96.