### PR TITLE
Rework filesystem handling

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -32,7 +32,7 @@ Dependencies
   .. note::
      At Notre Dame, a development version can be accessed via::
 
-      cctools=cctools-117-1cedc571-cvmfs-40cf5bba
+      cctools=cctools-118-29955e53-cvmfs-40cf5bba
       export PYTHONPATH=$PYTHONPATH:/afs/crc.nd.edu/group/ccl/software/$cctools/x86_64/redhat6/lib/python2.6/site-packages
       export PATH=/afs/crc.nd.edu/group/ccl/software/$cctools/x86_64/redhat6/bin:$PATH
 
@@ -107,6 +107,6 @@ Try manually installing ``numpy``::
 .. [#ftools] ``tcsh`` users should use the following to access the
    `cctools` development version at Notre Dame::
 
-    setenv cctools cctools-117-1cedc571-cvmfs-40cf5bba
+    setenv cctools cctools-118-29955e53-cvmfs-40cf5bba
     setenv PYTHONPATH ${PYTHONPATH}:/afs/crc.nd.edu/group/ccl/software/$cctools/x86_64/redhat6/lib/python2.6/site-packages
     setenv PATH /afs/crc.nd.edu/group/ccl/software/$cctools/x86_64/redhat6/bin:${PATH}

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -32,7 +32,7 @@ Dependencies
   .. note::
      At Notre Dame, a development version can be accessed via::
 
-      cctools=cctools-118-29955e53-cvmfs-40cf5bba
+      cctools=cctools-119-458db4f0-cvmfs-40cf5bba
       export PYTHONPATH=$PYTHONPATH:/afs/crc.nd.edu/group/ccl/software/$cctools/x86_64/redhat6/lib/python2.6/site-packages
       export PATH=/afs/crc.nd.edu/group/ccl/software/$cctools/x86_64/redhat6/bin:$PATH
 
@@ -107,6 +107,6 @@ Try manually installing ``numpy``::
 .. [#ftools] ``tcsh`` users should use the following to access the
    `cctools` development version at Notre Dame::
 
-    setenv cctools cctools-118-29955e53-cvmfs-40cf5bba
+    setenv cctools cctools-119-458db4f0-cvmfs-40cf5bba
     setenv PYTHONPATH ${PYTHONPATH}:/afs/crc.nd.edu/group/ccl/software/$cctools/x86_64/redhat6/lib/python2.6/site-packages
     setenv PATH /afs/crc.nd.edu/group/ccl/software/$cctools/x86_64/redhat6/bin:${PATH}

--- a/lobster/commands/process.py
+++ b/lobster/commands/process.py
@@ -137,6 +137,7 @@ class Process(Command):
             ttyfile = open(os.path.join(self.config.workdir, 'process.err'), 'a')
             logger.info("saving stderr and stdout to {0}".format(
                 os.path.join(self.config.workdir, 'process.err')))
+            args.preserve.append(ttyfile)
 
         if self.config.advanced.dump_core:
             logger.info("setting core dump size to unlimited")
@@ -151,8 +152,6 @@ class Process(Command):
 
         process = psutil.Process()
         preserved = [f.name for f in args.preserve]
-        if not args.foreground:
-            preserved.append(ttyfile.name)
         openfiles = [f for f in process.open_files() if f.path not in preserved]
         openconns = process.connections()
 

--- a/lobster/commands/process.py
+++ b/lobster/commands/process.py
@@ -146,6 +146,8 @@ class Process(Command):
         signals[signal.SIGINT] = lambda num, frame: Terminate().run(args)
         signals[signal.SIGTERM] = lambda num, frame: Terminate().run(args)
 
+        self.config.storage.deactivate()
+
         with daemon.DaemonContext(
                 detach_process=not args.foreground,
                 stdout=sys.stdout if args.foreground else ttyfile,
@@ -156,6 +158,8 @@ class Process(Command):
                 prevent_core=False,
                 initgroups=False,
                 signal_map=signals):
+            self.config.storage.activate()
+
             self.sprint()
 
             logger.info("lobster terminated")

--- a/lobster/commands/process.py
+++ b/lobster/commands/process.py
@@ -157,7 +157,7 @@ class Process(Command):
         if len(openconns) > 0 or len(openfiles) > 0:
             logger.error("cannot daemonize due to open files or connections")
             for f in openfiles:
-                logger.error("open file: {}".format(f.path))
+                logger.error("open file: {}".format(f))
             for c in openconns:
                 logger.error("open connection: {}".format(c))
             raise RuntimeError("open files or connections")

--- a/lobster/commands/process.py
+++ b/lobster/commands/process.py
@@ -151,6 +151,8 @@ class Process(Command):
 
         process = psutil.Process()
         preserved = [f.name for f in args.preserve]
+        if not args.foreground:
+            preserved.append(ttyfile.name)
         openfiles = [f for f in process.open_files() if f.path not in preserved]
         openconns = process.connections()
 

--- a/lobster/core/source.py
+++ b/lobster/core/source.py
@@ -186,7 +186,7 @@ class TaskProvider(object):
             if create and not util.checkpoint(self.workdir, wflow.label):
                 wflow.setup(self.workdir, self.basedirs)
                 logger.info("querying backend for {0}".format(wflow.label))
-                with fs.default():
+                with fs.alternative():
                     dataset_info = wflow.dataset.get_info()
 
                 logger.info("registering {0} in database".format(wflow.label))

--- a/lobster/core/workflow.py
+++ b/lobster/core/workflow.py
@@ -339,7 +339,7 @@ class Workflow(Configurable):
             logger.info("workflow {0}: adding output file(s) '{1}'".format(self.label, ', '.join(self.outputs)))
 
     def validate(self):
-        with fs.default():
+        with fs.alternative():
             if not self.dataset.validate():
                 msg = "cannot validate configuration for dataset of workflow '{0}'"
                 raise AttributeError(msg.format(self.label))

--- a/lobster/fs.py
+++ b/lobster/fs.py
@@ -1,9 +1,8 @@
 # This is not really a module, but some sort of perverse hack.  When
 # imported, i.e., with `import fs`, `fs` will not point to this module, but
-# to one instance of `se.StorageElement`.  See the documentation there...
-#
-# NB, creating a diferent instance of `StorageElement` is OK, since all
-# access methods are part of class variables, not instance variables.
+# to one instance of `se.FileSystem`.  This is done so that all python
+# files including `fs` within the same python process share one virtual
+# filesystem configuration.
 import se
 import sys
-sys.modules[__name__] = se.StorageElement()
+sys.modules[__name__] = se.FileSystem()

--- a/lobster/se.py
+++ b/lobster/se.py
@@ -124,6 +124,11 @@ class StorageElement(object):
 
     @classmethod
     def reset(cls):
+        cls._defaults = []
+        cls._systems = []
+
+    @classmethod
+    def clear(cls):
         cls._systems = []
 
     @classmethod
@@ -518,18 +523,28 @@ class StorageConfiguration(Configurable):
             else:
                 logger.debug("implementation of master access missing for URL {0}".format(url))
 
+    def deactivate(self):
+        """Clear all storage-element objects.
+
+        Needed when Lobster daemonizes, as filesystem objects may have
+        connections open that will get closed by daemonizing.  Underlying
+        objects may not realize that file descriptors are invalid and write
+        to newly opened files.
+        """
+        StorageElement.reset()
+
     def activate(self):
         """Sets file system access methods.
 
         Replaces default file system access methods with the ones specified
         per configuration for input and output storage element access.
         """
-        StorageElement.reset()
+        StorageElement.clear()
 
         self._initialize(self.input)
 
         StorageElement.store()
-        StorageElement.reset()
+        StorageElement.clear()
 
         self._initialize(self.output)
 

--- a/lobster/se.py
+++ b/lobster/se.py
@@ -29,7 +29,7 @@ class FileSystem(object):
     """
 
     _defaults = []
-    _fallback = []
+    _alternatives = []
 
     def __init__(self):
         self.__file__ = __file__
@@ -74,12 +74,12 @@ class FileSystem(object):
                 context of ``fs.alternative()``.
         """
         cls._defaults = defaults
-        cls._fallback = alternatives
+        cls._alternatives = alternatives
 
     @contextmanager
     def alternative(self):
         tmp = FileSystem._defaults
-        FileSystem._defaults = FileSystem._fallback
+        FileSystem._defaults = FileSystem._alternatives
         try:
             yield
         finally:

--- a/lobster/se.py
+++ b/lobster/se.py
@@ -24,7 +24,8 @@ class FileSystem(object):
     """Singleton class as an interface for filesystem interactions.
 
     Needs to be configured before first use, with two lists of
-    `StorageElement` implementations.
+    `StorageElement` implementations.  See the documentation of
+    ``configure()`` for details.
     """
 
     _defaults = []
@@ -59,6 +60,19 @@ class FileSystem(object):
 
     @classmethod
     def configure(cls, defaults, alternatives):
+        """Configure the filesystem access methods.
+
+        Parameters
+        ----------
+            defaults : list
+                List of :class:`StorageElement` implementations.  These
+                methods will be used in order by default to perform file
+                system interactions.
+            alternatives : list
+                As `defaults`, specifies methods to perform file system
+                interactions.  These methods are only active within the
+                context of ``fs.alternative()``.
+        """
         cls._defaults = defaults
         cls._fallback = alternatives
 

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         'matplotlib',
         'nose',
         'numpy>=1.9',
+        'psutil',
         'pycurl',
         'python-cjson', # actually a DBS dependency
         'python-daemon',

--- a/test/test_core_dataset.py
+++ b/test/test_core_dataset.py
@@ -34,7 +34,7 @@ class TestDataset(unittest.TestCase):
             s = se.StorageConfiguration(output=[], input=['file://' + self.workdir])
             s.activate()
 
-            with fs.default():
+            with fs.alternative():
                 info = Dataset(files='eggs').get_info()
                 assert len(info.files) == 10
 

--- a/test/test_se.py
+++ b/test/test_se.py
@@ -34,7 +34,7 @@ class TestSE(unittest.TestCase):
         s.activate()
 
         with util.PartiallyMutable.unlock():
-            with fs.default():
+            with fs.alternative():
                 ds = dataset.Dataset(files='spam/')
                 info = ds.get_info()
                 assert len(info.files) == 10


### PR DESCRIPTION
Does a few things:

* Clears filesystem interfaces before daemonizing
* Splits the `StorageElement` class by factoring out a `FileSystem` class — now code is split along functionality, with each class having one use-case
* Renames `default` to `alternative`, since the default filesystem interactions are output SE interactions, not input SE ones.

I don't know anymore what I was thinking implementing the FS code in the first place? I hope this iteration makes it easier to read and a little less magical?