### PR TITLE
XRootD StorageElement

### DIFF
--- a/lobster/core/data/task.py
+++ b/lobster/core/data/task.py
@@ -389,7 +389,7 @@ def copy_inputs(data, config, env):
                     timeout,
                     "xrdfs",
                     server,
-                    "ls",
+                    "stat",
                     os.path.join(path, file)
                 ]
 

--- a/lobster/core/task.py
+++ b/lobster/core/task.py
@@ -28,9 +28,12 @@ class TaskHandler(object):
         self._units = lumis
         self.outputs = outputs
         self._local = local
-
+        
         self.taskdir = taskdir
         self.unit_source = 'units_' + self._dataset
+
+        self.__output_info = {}
+        self.__output_size = 0
 
     @property
     def dataset(self):

--- a/lobster/se.py
+++ b/lobster/se.py
@@ -338,6 +338,97 @@ class SRM(StorageElement):
             paths = paths[50:]
 
 
+class XrootD(StorageElement):
+
+    def __init__(self, pfnprefix):
+        super(XrootD, self).__init__(pfnprefix)
+
+    def execute(self, cmd, *paths, **kwargs):
+
+        cmds = cmd.split()
+
+        output = []
+        for path in paths:
+
+            # Break the path into server and directory
+            protocol, server, path = url_re.match(path).groups()
+            args = ['xrdfs',server]+cmds+[path]
+            try:
+                p = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env={})
+                pout, err = p.communicate()
+                if p.returncode != 0 and not kwargs.get('safe', False):
+                    msg = "Failed to execute '{0}':\n{1}\n{2}".format(' '.join(args), err, pout)
+                    raise IOError(msg)
+                output.append(pout)
+            except OSError:
+                raise AttributeError("xrd utilities not available")
+
+
+        return '/n'.join(output)
+
+    def exists(self, path):
+        try:
+            self.execute('stat', path)
+            return True
+        except Exception:
+            return False
+
+    def getsize(self, path):
+        output = self.execute('stat', path)
+        for line in output.splitlines():
+            field,value = line.split(':')
+            if field == 'Size':
+                return value.strip()
+        
+        # Shouldn't get here unless we don't find the size.  Raise an exception
+        msg = 'xrdfs stat did not return file size.  Command output:\n{}'.format(output)
+        raise AttributeError(msg)
+
+    def isdir(self, path):
+        try:
+            output = self.execute('stat', path)
+            for line in output.splitlines():
+                field,value = line.split(':')
+                if field == 'Flags':
+                    return 'IsDir' in value
+
+            # If we got here, never found any mention of flags, just say false.
+            return False
+        except Exception:
+            return False
+
+    def isfile(self, path):
+        try:
+            output = self.execute('stat', path)
+            for line in output.splitlines():
+                field,value = line.split(':')
+                if field == 'Flags':
+                    return 'IsDir' not in value
+
+            # If we got here, never found any mention of flags, just say false.
+            return False
+        except Exception:
+            return False
+
+    def ls(self, path):
+        for p in self.execute('ls', path).splitlines():
+            yield os.path.join(path, p)
+
+    def mkdir(self, path, mode=None):
+        self.execute('mkdir -p', path)
+
+    def remove(self, *paths):
+        # It doesn't seem like Xrdfs supports either recursive or batch removal, so let's do it one at a time.
+        for path in paths:
+            if self.isdir(path):
+                for dirpath in self.ls(path):
+                    self.remove(dirpath) # Recursive because the directory might contain directories
+                self.execute('rmdir',path)
+            else:
+                self.execute('rm',path)
+
+
+
 class StorageConfiguration(Configurable):
 
     """

--- a/lobster/se.py
+++ b/lobster/se.py
@@ -415,7 +415,13 @@ class XrootD(StorageElement):
             return False
 
     def ls(self, path):
+        protocol, server, prepath = url_re.match(path).groups()
+        if not prepath.endswith('/'):
+            prepath+='/'
         for p in self.execute('ls', path).splitlines():
+            # Fun fact: xrdfs ls returns *absolute* paths but without the protocol.  Strip off the leading part.
+            p = p.replace(prepath,'',1)
+            logger.debug('from ls(): {}'.format(p))
             yield os.path.join(path, p)
 
     def mkdir(self, path, mode=None):
@@ -610,6 +616,8 @@ class StorageConfiguration(Configurable):
                     raise NotImplementedError("hadoop support is missing on this system")
             elif protocol == 'srm':
                 SRM(url)
+            elif protocol == 'root':
+                XrootD(url)
             else:
                 logger.debug("implementation of master access missing for URL {0}".format(url))
 

--- a/lobster/se.py
+++ b/lobster/se.py
@@ -388,9 +388,11 @@ class XrootD(StorageElement):
         try:
             output = self.execute('stat', path)
             for line in output.splitlines():
-                field,value = line.split(':')
+                field,value = line.split(':',1)
                 if field == 'Flags':
-                    return 'IsDir' in value
+                    # Do some silly stuff to get the flags...
+                    flags = value.split()[-1].strip('()').split('|')
+                    return 'IsDir' in flags
 
             # If we got here, never found any mention of flags, just say false.
             return False
@@ -401,9 +403,11 @@ class XrootD(StorageElement):
         try:
             output = self.execute('stat', path)
             for line in output.splitlines():
-                field,value = line.split(':')
+                field,value = line.split(':',1)
                 if field == 'Flags':
-                    return 'IsDir' not in value
+                    # Do some silly stuff to get the flags...
+                    flags = value.split()[-1].strip('()').split('|')
+                    return 'IsDir' not in flags
 
             # If we got here, never found any mention of flags, just say false.
             return False


### PR DESCRIPTION
The motivation behind this branch was to implement the necessary functionality to do file-based processing on a list of files or a directory only accessible via XRootD.  Note, I haven't been able to do any testing of the `remove` or `mkdir` functionality as I need to get access to a server that allows this.  (I'm told this is FNAL, but I need to reset my Kerberos password.)

Also, please look closely at f6d49c7.  It's not strictly related to XRootD, but I couldn't proceed with my testing without fixing what looked to me like a general bug in `TaskProvider`.  Maybe I'm misunderstanding something though.