### PR TITLE
Update lobster version log 

### DIFF
--- a/lobster/__init__.py
+++ b/lobster/__init__.py
@@ -1,2 +1,0 @@
-import cmssw
-import monitor

--- a/lobster/commands/process.py
+++ b/lobster/commands/process.py
@@ -128,7 +128,7 @@ class Process(Command):
 
         if not util.checkpoint(self.config.workdir, "version"):
             util.register_checkpoint(
-                self.config.workdir, "version", get_distribution('Lobster').version)
+                self.config.workdir, "version", util.get_version())
         else:
             util.verify(self.config.workdir)
 
@@ -175,6 +175,7 @@ class Process(Command):
         action = actions.Actions(self.config, task_src)
 
         logger.info("using wq from {0}".format(wq.__file__))
+        logger.info("Lobster version: " + util.get_version())
 
         wq.cctools_debug_flags_set("all")
         wq.cctools_debug_config_file(os.path.join(self.config.workdir, "work_queue_debug.log"))

--- a/lobster/util.py
+++ b/lobster/util.py
@@ -278,7 +278,7 @@ def id2dir(id):
     # Currently known limitations on the number of entries in a
     # sub-directory concern ext3, where said limit is 32k.  Use a
     # modus of 10k to split the task numbers.  Famous last words:
-    # "(10k)Â² tasks should be enough for everyone." we use two levels
+    # "(10k)squared tasks should be enough for everyone." ->we use two levels
     # only.
     id = int(id)
     man = str(id % 10000).zfill(4)

--- a/lobster/util.py
+++ b/lobster/util.py
@@ -7,7 +7,6 @@ import os
 import shlex
 import shutil
 import subprocess
-import yaml
 
 from contextlib import contextmanager
 from pkg_resources import get_distribution
@@ -325,6 +324,7 @@ def verify(workdir):
 
 
 def checkpoint(workdir, key):
+    import yaml
     statusfile = os.path.join(workdir, 'status.yaml')
     if os.path.exists(statusfile):
         with open(statusfile, 'rb') as f:
@@ -333,9 +333,11 @@ def checkpoint(workdir, key):
 
 
 def register_checkpoint(workdir, key, value):
+    import yaml
     statusfile = os.path.join(workdir, 'status.yaml')
     with open(statusfile, 'a') as f:
         yaml.dump({key: value}, f, default_flow_style=False)
+
 
 def get_version():
     if 'site-packages' in __file__:
@@ -349,6 +351,7 @@ def get_version():
         os.chdir(start)
         version = '{major}-{head}-{status}'.format(major=1.5, head=head, status=status)
     return version
+
 
 def verify_string(s):
     try:

--- a/lobster/util.py
+++ b/lobster/util.py
@@ -1,5 +1,13 @@
 # vim: set fileencoding=utf-8 :
 
+# Only use default packages here!  This package is included by `setup.py`.
+# Since this happens *before* dependencies are installed, only packages
+# included with the default python distribution should be imported at the
+# top level.
+#
+# If optional packages are needed, they should be included in the function
+# scope.
+
 import collections
 import inspect
 import logging

--- a/lobster/util.py
+++ b/lobster/util.py
@@ -10,8 +10,6 @@ import subprocess
 import yaml
 
 from contextlib import contextmanager
-from lockfile.pidlockfile import PIDLockFile
-from lockfile import AlreadyLocked
 from pkg_resources import get_distribution
 
 logger = logging.getLogger('lobster.util')
@@ -401,6 +399,9 @@ def ldd(name):
 
 
 def get_lock(workdir, force=False):
+    from lockfile.pidlockfile import PIDLockFile
+    from lockfile import AlreadyLocked
+
     pidfile = PIDLockFile(os.path.join(workdir, 'lobster.pid'), timeout=-1)
     try:
         pidfile.acquire()

--- a/lobster/util.py
+++ b/lobster/util.py
@@ -4,10 +4,10 @@ import collections
 import inspect
 import logging
 import os
+import shlex
 import shutil
 import subprocess
 import yaml
-import shlex
 
 from contextlib import contextmanager
 from lockfile.pidlockfile import PIDLockFile
@@ -278,7 +278,7 @@ def id2dir(id):
     # Currently known limitations on the number of entries in a
     # sub-directory concern ext3, where said limit is 32k.  Use a
     # modus of 10k to split the task numbers.  Famous last words:
-    # "(10k)squared tasks should be enough for everyone." ->we use two levels
+    # "(10k)^2 tasks should be enough for everyone." -> we use two levels
     # only.
     id = int(id)
     man = str(id % 10000).zfill(4)
@@ -314,7 +314,6 @@ def verify(workdir):
         return
 
     my_version = get_version()
-    #my_version = get_distribution('Lobster').version
     major,  head, status = my_version.split('-')
     my_version = major
 

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,13 @@
 #!/usr/bin/env python
 
-from setuptools import setup
 from lobster.util import get_version
+from setuptools import setup
 import subprocess
 import shlex
 
-#head = subprocess.check_output(shlex.split('git rev-parse --short HEAD')).strip()
-#diff = subprocess.check_output(shlex.split('git diff'))
-#status = 'dirty' if diff else 'clean'
-
 setup(
     name='Lobster',
-    version = get_version(),
-    #version = '{major}-{head}-{status}'.format(major=1.5, head=head, status=status),
+    version=get_version(),
     description='Opportunistic HEP computing tool',
     author='Anna Woodard, Matthias Wolf',
     url='https://github.com/matz-e/lobster',

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python
 
 from setuptools import setup
+import subprocess
+import shlex
+
+head = subprocess.check_output(shlex.split('git rev-parse --short HEAD')).strip()
+diff = subprocess.check_output(shlex.split('git diff'))
+status = 'dirty' if diff else 'clean'
 
 setup(
     name='Lobster',
-    version='1.5',
+    version = '{major}-{head}-{status}'.format(major=1.5, head=head, status=status),
     description='Opportunistic HEP computing tool',
     author='Anna Woodard, Matthias Wolf',
     url='https://github.com/matz-e/lobster',

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,18 @@
 #!/usr/bin/env python
 
 from setuptools import setup
+from lobster.util import get_version
 import subprocess
 import shlex
 
-head = subprocess.check_output(shlex.split('git rev-parse --short HEAD')).strip()
-diff = subprocess.check_output(shlex.split('git diff'))
-status = 'dirty' if diff else 'clean'
+#head = subprocess.check_output(shlex.split('git rev-parse --short HEAD')).strip()
+#diff = subprocess.check_output(shlex.split('git diff'))
+#status = 'dirty' if diff else 'clean'
 
 setup(
     name='Lobster',
-    version = '{major}-{head}-{status}'.format(major=1.5, head=head, status=status),
+    version = get_version(),
+    #version = '{major}-{head}-{status}'.format(major=1.5, head=head, status=status),
     description='Opportunistic HEP computing tool',
     author='Anna Woodard, Matthias Wolf',
     url='https://github.com/matz-e/lobster',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
-from lobster.util import get_version
 from setuptools import setup
+
+from lobster.util import get_version
 
 setup(
     name='Lobster',

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,6 @@
 
 from lobster.util import get_version
 from setuptools import setup
-import subprocess
-import shlex
 
 setup(
     name='Lobster',


### PR DESCRIPTION
Update the Lobster version representation.
For example: 2.1-a234fea-dirty (the last part marking uncommitted in changes)
Also print the Lobster version in process.log.

close #433

Also replace some special symbols, which cause weird characters for Putty users.
Make it more Windows friendly.