### PR TITLE
Adjust and extend efficiency plots.

### DIFF
--- a/lobster/commands/data/index.html
+++ b/lobster/commands/data/index.html
@@ -129,6 +129,8 @@
             <h3>Efficiency</h3>
             <a href="all/cpu-wall-hist.png"><img alt="" src="all/cpu-wall-hist.png"/></a>
             <a href="all/cpu-wall-int-hist.png"><img alt="" src="all/cpu-wall-int-hist.png"/></a>
+            <a href="all/cpu-cores-hist.png"><img alt="" src="all/cpu-cores-hist.png"/></a>
+            <a href="all/cpu-cores-int-hist.png"><img alt="" src="all/cpu-cores-int-hist.png"/></a>
         {% endif %}
         {% endif %}
         </div>


### PR DESCRIPTION
Instead of running tasks, divide by committed cores for the efficiency
plots.  Also provide a plot which has the CPU time divided by the number of
available cores, to show dips in efficiency due to unused resources.

Maybe similar to #484?

I'll see about adjusting the pie-chart a little, too.