### PR TITLE
Add pythonic hadoop support via snakebite.

### DIFF
--- a/examples/mc_gen.py
+++ b/examples/mc_gen.py
@@ -8,7 +8,7 @@ version = datetime.datetime.now().strftime('%Y%m%d')
 
 storage = StorageConfiguration(
     output=[
-        "hdfs:///store/user/$USER/lobster_mc_" + version,
+        "hdfs://eddie.crrc.nd.edu:19000/store/user/$USER/lobster_mc_" + version,
         "file:///hadoop/store/user/$USER/lobster_mc_" + version,
         "root://deepthought.crc.nd.edu//store/user/$USER/lobster_mc_" + version,
         "chirp://eddie.crc.nd.edu:9094/store/user/$USER/lobster_test_" + version,

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -7,8 +7,8 @@ version = datetime.datetime.now().strftime('%Y%m%d_%H%M')
 
 storage = StorageConfiguration(
     output=[
+        "hdfs://eddie.crc.nd.edu:19000/store/user/$USER/lobster_test_" + version,
         "file:///hadoop/store/user/$USER/lobster_test_" + version,
-        "hdfs:///store/user/$USER/lobster_test_" + version,
         # ND is not in the XrootD redirector, thus hardcode server.
         # Note the double-slash after the hostname!
         "root://deepthought.crc.nd.edu//store/user/$USER/lobster_test_" + version,

--- a/lobster/se.py
+++ b/lobster/se.py
@@ -593,7 +593,7 @@ class StorageConfiguration(Configurable):
                 Local(path)
             elif protocol == 'hdfs':
                 host, port = server.split(':')
-                    Hadoop(host, port, path)
+                Hadoop(host, port, path)
             elif protocol == 'srm':
                 SRM(url)
             elif protocol == 'root':

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
         'pyxdg',
         'requests',
         'retrying',
+        'snakebite<2.0',
         'WMCore'
     ],
     dependency_links=[

--- a/test/test_se.py
+++ b/test/test_se.py
@@ -73,13 +73,12 @@ if 'LOBSTER_SKIP_HADOOP' not in os.environ:
     class TestHadoop(TestSE):
 
         def runTest(self):
-            self.query('hdfs://' + self.workdir.replace('/hadoop', '', 1))
+            self.query('hdfs://eddie.crc.nd.edu:19000' + self.workdir.replace('/hadoop', '', 1))
 
     class TestHadoopPermissions(TestSE):
 
         def runTest(self):
-            self.permissions(
-                'hdfs://' + self.workdir.replace('/hadoop', '', 1))
+            self.permissions('hdfs://eddie.crc.nd.edu:19000' + self.workdir.replace('/hadoop', '', 1))
 
 if 'LOBSTER_SKIP_SRM' not in os.environ:
     class TestSRM(TestSE):


### PR DESCRIPTION
Fixes #494.  Kudos to @klannon for digging this up.  This will make
filesystem operation a lot faster by not relying on the `hadoop` command
being available, and not going through the process of starting a JVM for
every filesystem query.