### PR TITLE
Rewrite Storage Element support

### DIFF
--- a/lobster/commands/process.py
+++ b/lobster/commands/process.py
@@ -123,6 +123,7 @@ class Process(Command, util.Timing):
             ttyfile = open(os.path.join(self.config.workdir, 'process.err'), 'a')
             logger.info("saving stderr and stdout to {0}".format(
                 os.path.join(self.config.workdir, 'process.err')))
+            args.preserve.append(ttyfile)
 
         if self.config.advanced.dump_core:
             logger.info("setting core dump size to unlimited")
@@ -138,8 +139,6 @@ class Process(Command, util.Timing):
 
         process = psutil.Process()
         preserved = [f.name for f in args.preserve]
-        if not args.foreground:
-            preserved.append(ttyfile.name)
         openfiles = [f for f in process.open_files() if f.path not in preserved]
         openconns = process.connections()
 

--- a/lobster/commands/process.py
+++ b/lobster/commands/process.py
@@ -4,6 +4,7 @@ import inspect
 import logging
 import logging.handlers
 import os
+import psutil
 import resource
 import signal
 import sys
@@ -134,6 +135,19 @@ class Process(Command, util.Timing):
         signals = daemon.daemon.make_default_signal_map()
         signals[signal.SIGINT] = localkill
         signals[signal.SIGTERM] = localkill
+
+        process = psutil.Process()
+        preserved = [f.name for f in args.preserve]
+        openfiles = [f for f in process.open_files() if f.path not in preserved]
+        openconns = process.connections()
+
+        if len(openconns) > 0 or len(openfiles) > 0:
+            logger.error("cannot daemonize due to open files or connections")
+            for f in openfiles:
+                logger.error("open file: {}".format(f.path))
+            for c in openconns:
+                logger.error("open connection: {}".format(c))
+            raise RuntimeError("open files or connections")
 
         with daemon.DaemonContext(
                 detach_process=not args.foreground,

--- a/lobster/commands/process.py
+++ b/lobster/commands/process.py
@@ -144,7 +144,7 @@ class Process(Command, util.Timing):
         if len(openconns) > 0 or len(openfiles) > 0:
             logger.error("cannot daemonize due to open files or connections")
             for f in openfiles:
-                logger.error("open file: {}".format(f.path))
+                logger.error("open file: {}".format(f))
             for c in openconns:
                 logger.error("open connection: {}".format(c))
             raise RuntimeError("open files or connections")

--- a/lobster/commands/process.py
+++ b/lobster/commands/process.py
@@ -138,6 +138,8 @@ class Process(Command, util.Timing):
 
         process = psutil.Process()
         preserved = [f.name for f in args.preserve]
+        if not args.foreground:
+            preserved.append(ttyfile.name)
         openfiles = [f for f in process.open_files() if f.path not in preserved]
         openconns = process.connections()
 

--- a/lobster/core/source.py
+++ b/lobster/core/source.py
@@ -190,7 +190,7 @@ class TaskProvider(util.Timing):
             if create and not util.checkpoint(self.workdir, wflow.label):
                 wflow.setup(self.workdir, self.basedirs)
                 logger.info("querying backend for {0}".format(wflow.label))
-                with fs.default():
+                with fs.alternative():
                     dataset_info = wflow.dataset.get_info()
 
                 logger.info("registering {0} in database".format(wflow.label))

--- a/lobster/core/workflow.py
+++ b/lobster/core/workflow.py
@@ -345,7 +345,7 @@ class Workflow(Configurable):
             logger.info("workflow {0}: adding output file(s) '{1}'".format(self.label, ', '.join(self.outputs)))
 
     def validate(self):
-        with fs.default():
+        with fs.alternative():
             if not self.dataset.validate():
                 msg = "cannot validate configuration for dataset of workflow '{0}'"
                 raise AttributeError(msg.format(self.label))

--- a/lobster/fs.py
+++ b/lobster/fs.py
@@ -1,9 +1,8 @@
 # This is not really a module, but some sort of perverse hack.  When
 # imported, i.e., with `import fs`, `fs` will not point to this module, but
-# to one instance of `se.StorageElement`.  See the documentation there...
-#
-# NB, creating a diferent instance of `StorageElement` is OK, since all
-# access methods are part of class variables, not instance variables.
+# to one instance of `se.FileSystem`.  This is done so that all python
+# files including `fs` within the same python process share one virtual
+# filesystem configuration.
 import se
 import sys
-sys.modules[__name__] = se.StorageElement()
+sys.modules[__name__] = se.FileSystem()

--- a/lobster/se.py
+++ b/lobster/se.py
@@ -29,7 +29,7 @@ class FileSystem(object):
     """
 
     _defaults = []
-    _fallback = []
+    _alternatives = []
 
     def __init__(self):
         self.__file__ = __file__
@@ -74,12 +74,12 @@ class FileSystem(object):
                 context of ``fs.alternative()``.
         """
         cls._defaults = defaults
-        cls._fallback = alternatives
+        cls._alternatives = alternatives
 
     @contextmanager
     def alternative(self):
         tmp = FileSystem._defaults
-        FileSystem._defaults = FileSystem._fallback
+        FileSystem._defaults = FileSystem._alternatives
         try:
             yield
         finally:

--- a/lobster/se.py
+++ b/lobster/se.py
@@ -28,7 +28,7 @@ class FileSystem(object):
     """
 
     _defaults = []
-    _systems = []
+    _fallback = []
 
     def __init__(self):
         self.__file__ = __file__
@@ -42,7 +42,7 @@ class FileSystem(object):
             logger.debug(
                 "resolving file system method '{0}' with arguments {1!r}, {2!r}".format(attr, args, kwargs))
             lasterror = None
-            for imp in FileSystem._systems:
+            for imp in FileSystem._defaults:
                 try:
                     return imp.fixresult(getattr(imp, attr)(*map(imp.lfn2pfn, args), **kwargs))
                 except (IOError, OSError) as e:
@@ -58,18 +58,18 @@ class FileSystem(object):
         return switch
 
     @classmethod
-    def configure(cls, defaults, systems):
+    def configure(cls, defaults, alternatives):
         cls._defaults = defaults
-        cls._systems = systems
+        cls._fallback = alternatives
 
     @contextmanager
-    def default(self):
-        tmp = FileSystem._systems
-        FileSystem._systems = FileSystem._defaults
+    def alternative(self):
+        tmp = FileSystem._defaults
+        FileSystem._defaults = FileSystem._fallback
         try:
             yield
         finally:
-            FileSystem._systems = tmp
+            FileSystem._defaults = tmp
 
 
 class StorageElement(object):
@@ -617,8 +617,8 @@ class StorageConfiguration(Configurable):
         per configuration for input and output storage element access.
         """
         FileSystem.configure(
-            list(self._initialize(self.input)),
-            list(self._initialize(self.output))
+            list(self._initialize(self.output)),
+            list(self._initialize(self.input))
         )
 
     def preprocess(self, parameters, merge):

--- a/lobster/se.py
+++ b/lobster/se.py
@@ -24,7 +24,8 @@ class FileSystem(object):
     """Singleton class as an interface for filesystem interactions.
 
     Needs to be configured before first use, with two lists of
-    `StorageElement` implementations.
+    `StorageElement` implementations.  See the documentation of
+    ``configure()`` for details.
     """
 
     _defaults = []
@@ -59,6 +60,19 @@ class FileSystem(object):
 
     @classmethod
     def configure(cls, defaults, alternatives):
+        """Configure the filesystem access methods.
+
+        Parameters
+        ----------
+            defaults : list
+                List of :class:`StorageElement` implementations.  These
+                methods will be used in order by default to perform file
+                system interactions.
+            alternatives : list
+                As `defaults`, specifies methods to perform file system
+                interactions.  These methods are only active within the
+                context of ``fs.alternative()``.
+        """
         cls._defaults = defaults
         cls._fallback = alternatives
 

--- a/lobster/se.py
+++ b/lobster/se.py
@@ -19,54 +19,30 @@ logger = logging.getLogger('lobster.se')
 url_re = re.compile(r'^([a-z]+)://([^/]*)(.*)/?$')
 
 
-class StorageElement(object):
+class FileSystem(object):
 
-    """Weird class to handle all needs of storage implementations.
+    """Singleton class as an interface for filesystem interactions.
 
-    This class can be used for file system operations after at least one of
-    its subclasses has been instantiated.
-
-    "One size fits nobody." (T. Pratchett)
+    Needs to be configured before first use, with two lists of
+    `StorageElement` implementations.
     """
+
     _defaults = []
     _systems = []
 
-    def __init__(self, pfnprefix=None):
-        """Create or use a StorageElement abstraction.
-
-        As a user, use with no parameters to access various storage
-        elements transparently.
-
-        Subclasses should call the constructor with appropriate arguments,
-        which should also be made available to the user.
-
-        Parameters
-        ----------
-        pfnprefix : string, optional
-            The path prefix under which relative file names can be
-            accessed.
-        """
-        self.__master = False
-
-        if pfnprefix is not None:
-            self._pfnprefix = pfnprefix
-            if not self._pfnprefix.endswith('/'):
-                self._pfnprefix += '/'
-            StorageElement._systems.append(self)
-        else:
-            self.__master = True
-            self.__file__ = __file__
-            self.__name__ = 'fs'
+    def __init__(self):
+        self.__file__ = __file__
+        self.__name__ = 'fs'
 
     def __getattr__(self, attr):
-        if attr in self.__dict__ or not self.__master:
+        if attr in self.__dict__:
             return self.__dict__[attr]
 
         def switch(*args, **kwargs):
             logger.debug(
                 "resolving file system method '{0}' with arguments {1!r}, {2!r}".format(attr, args, kwargs))
             lasterror = None
-            for imp in StorageElement._systems:
+            for imp in FileSystem._systems:
                 try:
                     return imp.fixresult(getattr(imp, attr)(*map(imp.lfn2pfn, args), **kwargs))
                 except (IOError, OSError) as e:
@@ -80,6 +56,42 @@ class StorageElement(object):
             raise AttributeError(
                 "no resolution found for method '{0}' with arguments '{1}': {2}".format(attr, args, lasterror))
         return switch
+
+    @classmethod
+    def configure(cls, defaults, systems):
+        cls._defaults = defaults
+        cls._systems = systems
+
+    @contextmanager
+    def default(self):
+        tmp = FileSystem._systems
+        FileSystem._systems = FileSystem._defaults
+        try:
+            yield
+        finally:
+            FileSystem._systems = tmp
+
+
+class StorageElement(object):
+
+    """Storage Element base class.
+
+    Provides some basic handling of relative paths.  To be subclassed by
+    implementations.
+    """
+
+    def __init__(self, pfnprefix):
+        """Baseclass of a storage element.
+
+        Parameters
+        ----------
+        pfnprefix : string
+            The path prefix under which relative file names can be
+            accessed.
+        """
+        self._pfnprefix = pfnprefix
+        if not self._pfnprefix.endswith('/'):
+            self._pfnprefix += '/'
 
     def lfn2pfn(self, path):
         if path.startswith('/'):
@@ -121,23 +133,6 @@ class StorageElement(object):
             return
         mode = self.permissions(parent)
         self.mkdir(path, mode=mode)
-
-    @classmethod
-    def reset(cls):
-        cls._systems = []
-
-    @classmethod
-    def store(cls):
-        cls._defaults = list(cls._systems)
-
-    @contextmanager
-    def default(self):
-        tmp = StorageElement._systems
-        StorageElement._systems = self._defaults
-        try:
-            yield
-        finally:
-            StorageElement._systems = tmp
 
 
 class Local(StorageElement):
@@ -598,20 +593,20 @@ class StorageConfiguration(Configurable):
 
             if protocol == 'chirp':
                 try:
-                    Chirp(server, path)
+                    yield Chirp(server, path)
                 except chirp.AuthenticationFailure:
                     raise AttributeError("cannot access chirp server")
             elif protocol == 'file':
-                Local(path)
+                yield Local(path)
             elif protocol == 'hdfs':
                 try:
-                    Hadoop(path)
+                    yield Hadoop(path)
                 except NameError:
                     raise NotImplementedError("hadoop support is missing on this system")
             elif protocol == 'srm':
-                SRM(url)
+                yield SRM(url)
             elif protocol == 'root':
-                XrootD(url)
+                yield XrootD(url)
             else:
                 logger.debug("implementation of master access missing for URL {0}".format(url))
 
@@ -621,14 +616,10 @@ class StorageConfiguration(Configurable):
         Replaces default file system access methods with the ones specified
         per configuration for input and output storage element access.
         """
-        StorageElement.reset()
-
-        self._initialize(self.input)
-
-        StorageElement.store()
-        StorageElement.reset()
-
-        self._initialize(self.output)
+        FileSystem.configure(
+            list(self._initialize(self.input)),
+            list(self._initialize(self.output))
+        )
 
     def preprocess(self, parameters, merge):
         """Adjust the storage transfer parameters sent with a task.

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         'matplotlib',
         'nose',
         'numpy>=1.9',
+        'psutil',
         'pycurl',
         'python-cjson',  # actually a DBS dependency
         'python-daemon',

--- a/test/test_core_dataset.py
+++ b/test/test_core_dataset.py
@@ -37,7 +37,7 @@ class TestDataset(unittest.TestCase):
                 output=[], input=['file://' + self.workdir])
             s.activate()
 
-            with fs.default():
+            with fs.alternative():
                 info = Dataset(files='eggs').get_info()
                 assert len(info.files) == 10
 

--- a/test/test_se.py
+++ b/test/test_se.py
@@ -36,7 +36,7 @@ class TestSE(unittest.TestCase):
         s.activate()
 
         with util.PartiallyMutable.unlock():
-            with fs.default():
+            with fs.alternative():
                 ds = dataset.Dataset(files='spam/')
                 info = ds.get_info()
                 assert len(info.files) == 10


### PR DESCRIPTION
See #448 — this time solved a bit differently.  Instead of deactivating and re-instating the file system access methods, gathers the file-descriptors of the open connections and have them be preserved.

Needed for #495.