### PR TITLE
Storage fixes

### DIFF
--- a/lobster/commands/validate.py
+++ b/lobster/commands/validate.py
@@ -23,7 +23,6 @@ class Validate(Command):
         logger = logging.getLogger('lobster.validate')
 
         store = UnitStore(config)
-        config.storage.activate()
 
         stats = dict((w.label, [0, 0]) for w in config.workflows)
 

--- a/lobster/core/config.py
+++ b/lobster/core/config.py
@@ -133,7 +133,7 @@ class Config(Configurable):
         try:
             with open(os.path.join(path, 'config.pkl'), 'rb') as f:
                 cfg = pickle.load(f)
-                cfg.storage.activate()
+                cfg.storage.activate(failures=False)
                 return cfg
         except IOError as e:
             print e

--- a/lobster/se.py
+++ b/lobster/se.py
@@ -480,8 +480,8 @@ class StorageConfiguration(Configurable):
             URLs will be attempted for all input files.
     """
     _mutable = {
-        'input': (None, [], False),
-        'output': (None, [], False)
+        'input': ('config.storage.activate', [], False),
+        'output': ('config.storage.activate', [], False)
     }
 
     # Map protocol shorthands to actual protocol names


### PR DESCRIPTION
As requested by @klannon, and now facilitated by some refactoring, connecting to the Chirp server should only fail when a configuration is started.

When using the working directory with the `lobster` command, failures to access the Chirp server are ignored, and Chirp will not be used by the master.