### PR TITLE
Guard certain dashboard interactions against failures.

### DIFF
--- a/lobster/cmssw/dash.py
+++ b/lobster/cmssw/dash.py
@@ -46,6 +46,20 @@ conf = {
 
 
 def mayfail(errors, retval=None):
+    """Allow decorated methods to fail with certain errors.
+
+    Will return `retval` when the decorated method fails with the
+    exception(s) specified by `errors`.
+
+    Parameters
+    ----------
+    errors : type or list of type
+        An `Exception` subclass or list thereof that are considered
+        non-fatal.
+    retval, optional
+        The return value of the decorated function if it throws a non-fatal
+        exception.
+    """
     def wrapper(fct):
         def decorator(*args, **kwargs):
             try:


### PR DESCRIPTION
Helps when SiteDB becomes unreachable, but only do so for task registration
and updates.  If a project can't be registered, the dashboard monitoring
should be disabled.

Fixes #502.