### PR TITLE
Email notification

### DIFF
--- a/lobster/commands/process.py
+++ b/lobster/commands/process.py
@@ -357,6 +357,7 @@ class Process(Command, util.Timing):
                     raise
         if units_left == 0:
             logger.info("no more work left to do")
+            util.sendemail("Your job is done!", self.config.advanced.email_address)
             if self.config.elk:
                 self.config.elk.end()
             if action:

--- a/lobster/commands/process.py
+++ b/lobster/commands/process.py
@@ -351,13 +351,14 @@ class Process(Command, util.Timing):
                 except Exception:
                     tb = traceback.format_exc()
                     logger.critical("cannot recover from the following exception:\n" + tb)
+                    util.sendemail("You job has crashed from the following exception:\n" + tb, self.config)
                     for task in tasks:
                         logger.critical(
                             "tried to return task {0} from {1}".format(task.tag, task.hostname))
                     raise
         if units_left == 0:
             logger.info("no more work left to do")
-            util.sendemail("Your job is done!", self.config.advanced.email_address)
+            util.sendemail("Your job is done!", self.config)
             if self.config.elk:
                 self.config.elk.end()
             if action:

--- a/lobster/core/config.py
+++ b/lobster/core/config.py
@@ -173,6 +173,8 @@ class AdvancedOptions(Configurable):
             tasks send to it.
         dump_core : bool
             Produce core dumps.  Useful to debug `WorkQueue`.
+        email_address : str
+            The email address you want to receive emails from Lobster.
         full_monitoring : bool
             Produce full monitoring output.  Useful to debug `WorkQueue`.
         log_level : int
@@ -217,6 +219,7 @@ class AdvancedOptions(Configurable):
                  abort_multiplier=4,
                  bad_exit_codes=None,
                  dump_core=False,
+                 email_address=None,
                  full_monitoring=False,
                  log_level=2,
                  osg_version=None,
@@ -241,6 +244,7 @@ class AdvancedOptions(Configurable):
         self.abort_multiplier = abort_multiplier
         self.bad_exit_codes = bad_exit_codes if bad_exit_codes else [169]
         self.dump_core = dump_core
+        self.email_address = email_address
         self.full_monitoring = full_monitoring
         self.log_level = log_level
         self.payload = payload

--- a/lobster/core/config.py
+++ b/lobster/core/config.py
@@ -173,7 +173,7 @@ class AdvancedOptions(Configurable):
             tasks send to it.
         dump_core : bool
             Produce core dumps.  Useful to debug `WorkQueue`.
-        email_address : str
+        email : str
             The email address you want to receive emails from Lobster.
         full_monitoring : bool
             Produce full monitoring output.  Useful to debug `WorkQueue`.
@@ -219,7 +219,7 @@ class AdvancedOptions(Configurable):
                  abort_multiplier=4,
                  bad_exit_codes=None,
                  dump_core=False,
-                 email_address=None,
+                 email=None,
                  full_monitoring=False,
                  log_level=2,
                  osg_version=None,
@@ -244,7 +244,7 @@ class AdvancedOptions(Configurable):
         self.abort_multiplier = abort_multiplier
         self.bad_exit_codes = bad_exit_codes if bad_exit_codes else [169]
         self.dump_core = dump_core
-        self.email_address = email_address
+        self.email = email
         self.full_monitoring = full_monitoring
         self.log_level = log_level
         self.payload = payload

--- a/lobster/core/source.py
+++ b/lobster/core/source.py
@@ -145,6 +145,7 @@ class TaskProvider(util.Timing):
         logger.debug("using {} as proxy for CVMFS".format(self.__cvmfs_proxy))
         logger.debug("using {} as proxy for Frontier".format(self.__frontier_proxy))
         logger.debug("using {} as osg_version".format(self.config.advanced.osg_version))
+        util.sendemail("Your Lobster job has started!", self.config)
 
         self.__taskhandlers = {}
         self.__store = unit.UnitStore(self.config)

--- a/lobster/monitor/elk/interface.py
+++ b/lobster/monitor/elk/interface.py
@@ -1132,10 +1132,12 @@ class ElkInterface(Configurable):
 
         for item in list(summary)[1:]:
             workflow_summary = dict(zip(keys, item))
-            workflow_summary['percent_progress'] = \
-                float(workflow_summary['percent_progress'].replace('%', ''))
-            workflow_summary['percent_merged'] = \
-                float(workflow_summary['percent_merged'].replace('%', ''))
+            if workflow_summary['percent_progress']:
+                workflow_summary['percent_progress'] = \
+                    float(workflow_summary['percent_progress'].replace('%', ''))
+            if workflow_summary['percent_merged']:
+                workflow_summary['percent_merged'] = \
+                    float(workflow_summary['percent_merged'].replace('%', ''))
 
             workflow_summaries[workflow_summary['label']] = workflow_summary
 

--- a/lobster/util.py
+++ b/lobster/util.py
@@ -15,10 +15,12 @@ import logging
 import os
 import shlex
 import shutil
+import smtplib
 import subprocess
 import time
 
 from contextlib import contextmanager
+from email.mime.text import MIMEText
 from pkg_resources import get_distribution
 
 logger = logging.getLogger('lobster.util')
@@ -375,6 +377,16 @@ def register_checkpoint(workdir, key, value):
             json.dump(s, f, sort_keys=True, indent=4)
             f.write('\n')
 
+def sendemail(emailmsg, you):
+    if you:
+        msg = MIMEText(emailmsg)
+        me = 'Lobster@nd.edu'
+        msg['Subject'] = 'No Reply'
+        msg['From'] = me
+        msg['To'] = you
+        s = smtplib.SMTP('localhost')
+        s.sendmail(me,[you], msg.as_string())
+        s.quit()
 
 def get_version():
     if 'site-packages' in __file__:

--- a/lobster/util.py
+++ b/lobster/util.py
@@ -382,7 +382,7 @@ def sendemail(emailmsg, config):
     you = config.advanced.email
     if you:
         msg = MIMEText(emailmsg + "\n\n" + "workdir: " + config.workdir + "\n" + "plotdir: " + config.plotdir + "\n\n" + "From Notre Dame Lobster Team")
-        me = 'Lobster@nd.edu'
+        me = you
         msg['Subject'] = 'Notre Dame Lobster -- No Reply'
         msg['From'] = me
         msg['To'] = you

--- a/lobster/util.py
+++ b/lobster/util.py
@@ -377,11 +377,12 @@ def register_checkpoint(workdir, key, value):
             json.dump(s, f, sort_keys=True, indent=4)
             f.write('\n')
 
-def sendemail(emailmsg, you):
+def sendemail(emailmsg, config):
+    you = config.advanced.email_address
     if you:
-        msg = MIMEText(emailmsg)
+        msg = MIMEText(emailmsg + "\n\n" + "workdir: " + config.workdir + "\n" + "plotdir: " + config.plotdir + "\n\n" + "From Notre Dame Lobster Team")
         me = 'Lobster@nd.edu'
-        msg['Subject'] = 'No Reply'
+        msg['Subject'] = 'Notre Dame Lobster -- No Reply'
         msg['From'] = me
         msg['To'] = you
         s = smtplib.SMTP('localhost')

--- a/lobster/util.py
+++ b/lobster/util.py
@@ -377,8 +377,9 @@ def register_checkpoint(workdir, key, value):
             json.dump(s, f, sort_keys=True, indent=4)
             f.write('\n')
 
+
 def sendemail(emailmsg, config):
-    you = config.advanced.email_address
+    you = config.advanced.email
     if you:
         msg = MIMEText(emailmsg + "\n\n" + "workdir: " + config.workdir + "\n" + "plotdir: " + config.plotdir + "\n\n" + "From Notre Dame Lobster Team")
         me = 'Lobster@nd.edu'
@@ -386,8 +387,9 @@ def sendemail(emailmsg, config):
         msg['From'] = me
         msg['To'] = you
         s = smtplib.SMTP('localhost')
-        s.sendmail(me,[you], msg.as_string())
+        s.sendmail(me, [you], msg.as_string())
         s.quit()
+
 
 def get_version():
     if 'site-packages' in __file__:


### PR DESCRIPTION
Fix #38 

Lobster will send emails to users under these circumstances:
1. Lobster started successfully (Not sure if this is useful. But sometimes Lobster won't start successfully.)
2. Lobster crashed. (Catch most of the crashes)
3. Lobster finished.
The email will also include `workdir` and `plotdir`.
Users need to specify their emails in `Advance Config`. Nothing will happen if no emails are provided.
