### PR TITLE
Better sqlite handling

### DIFF
--- a/lobster/cmssw/dataset.py
+++ b/lobster/cmssw/dataset.py
@@ -205,6 +205,6 @@ class Dataset(Configurable):
             logger.debug("split lumis detected in {} - "
                          "{} unique (run, lumi) but "
                          "{} unique (run, lumi, file) - "
-                         "enforcing a limit of one file per task".format(dataset, total_lumis, result.total_units))
+                         "enforcing a limit of one file per task".format(self.dataset, total_lumis, result.total_units))
 
         return result

--- a/lobster/cmssw/dataset.py
+++ b/lobster/cmssw/dataset.py
@@ -159,6 +159,7 @@ class Dataset(Configurable):
         result = self.__cache.cached(dataset, baseinfo)
         if result:
             return result
+        total_lumis = sum([info['num_lumi'] for info in baseinfo])
 
         result = DatasetInfo()
         result.total_events = sum([info['num_event'] for info in baseinfo])
@@ -190,5 +191,12 @@ class Dataset(Configurable):
         result.total_units = result.unmasked_units + result.masked_units
 
         self.__cache.cache(dataset, baseinfo, result)
+
+        result.stop_on_file_boundary = (result.total_units != total_lumis)
+        if result.stop_on_file_boundary:
+            logger.debug("split lumis detected in {} - "
+                         "{} unique (run, lumi) but "
+                         "{} unique (run, lumi, file) - "
+                         "enforcing a limit of one file per task".format(dataset, total_lumis, result.total_units))
 
         return result

--- a/lobster/core/data/task.py
+++ b/lobster/core/data/task.py
@@ -57,6 +57,7 @@ class Mangler(logging.Formatter):
         chevron = '>' * (record.levelno / logging.DEBUG + 1)
         return fmt.format(chevron=chevron, message=record.msg, date=time.strftime("%c"), context=self.context)
 
+
 mangler = Mangler()
 
 console = logging.StreamHandler()
@@ -1014,6 +1015,7 @@ def write_zipfiles(data):
             zipf = gzip.open(filename + ".gz", "wb")
             zipf.writelines(f)
             zipf.close()
+
 
 data = {
     'files': {

--- a/lobster/core/dataset.py
+++ b/lobster/core/dataset.py
@@ -39,6 +39,7 @@ class DatasetInfo(object):
     def __init__(self):
         self.file_based = False
         self.files = defaultdict(FileInfo)
+        self.stop_on_file_boundary = False
         self.tasksize = 1
         self.total_events = 0
         self.total_units = 0
@@ -93,6 +94,7 @@ class Dataset(Configurable):
 
 
 class EmptyDataset(Configurable):
+
     """
     Dataset specification for non-cmsRun workflows with no input files.
 
@@ -121,6 +123,7 @@ class EmptyDataset(Configurable):
 
 
 class ProductionDataset(Configurable):
+
     """
     Dataset specification for Monte-Carlo event generation.
 
@@ -167,6 +170,7 @@ class ProductionDataset(Configurable):
 
 
 class MultiProductionDataset(ProductionDataset):
+
     """
     Dataset specification for Monte-Carlo event generation from a set
     of gridpacks.
@@ -218,6 +222,7 @@ class MultiProductionDataset(ProductionDataset):
 
 
 class ParentDataset(Configurable):
+
     """
     Process the output of another workflow.
 

--- a/lobster/core/task.py
+++ b/lobster/core/task.py
@@ -17,6 +17,7 @@ logger = logging.getLogger('lobster.cmssw.taskhandler')
 
 
 class TaskHandler(object):
+
     """
     Handles mapping of lumi sections to files etc.
     """
@@ -24,7 +25,7 @@ class TaskHandler(object):
     def __init__(self, id, dataset, files, lumis, outputs, taskdir, local=False):
         self._id = id
         self._dataset = dataset
-        self._files = [(id, file) for id, file in files]
+        self._files = [(i, file) for i, file in files]
         self._file_based = any([file_ is None or run < 0 or lumi < 0 for (_, file_, run, lumi) in lumis])
         self._units = lumis
         self.outputs = outputs
@@ -80,11 +81,9 @@ class TaskHandler(object):
                         unit_update.append((unit.FAILED, lumi_id))
                         units_processed -= 1
                 elif not self._file_based:
-                    file_lumis = set(files_info[file][1])
+                    file_lumis = set(map(tuple, files_info[file][1]))
                     for (lumi_id, lumi_file, r, l) in file_units:
-                        logger.error('FILE UNITS %s' % file_units)
                         if (r, l) not in file_lumis:
-                            logger.error('FILE LUMIS %s' % file_lumis)
                             unit_update.append((unit.FAILED, lumi_id))
                             units_processed -= 1
 
@@ -269,6 +268,7 @@ class TaskHandler(object):
 
 
 class MergeTaskHandler(TaskHandler):
+
     def __init__(self, id_, dataset, files, lumis, outputs, taskdir):
         super(MergeTaskHandler, self).__init__(id_, dataset, files, lumis, outputs, taskdir)
         self._local = True
@@ -281,6 +281,7 @@ class MergeTaskHandler(TaskHandler):
 
 
 class ProductionTaskHandler(TaskHandler):
+
     def __init__(self, id_, dataset, lumis, outputs, taskdir):
         super(ProductionTaskHandler, self).__init__(id_, dataset, [], lumis, outputs, taskdir)
         self._file_based = True
@@ -295,6 +296,7 @@ class ProductionTaskHandler(TaskHandler):
 
 
 class MultiProductionTaskHandler(ProductionTaskHandler):
+
     def __init__(self, id_, dataset, gridpacks, lumis, outputs, taskdir):
         super(ProductionTaskHandler, self).__init__(id_, dataset, gridpacks, lumis, outputs, taskdir)
         self._file_based = True

--- a/lobster/core/task.py
+++ b/lobster/core/task.py
@@ -80,9 +80,11 @@ class TaskHandler(object):
                         unit_update.append((unit.FAILED, lumi_id))
                         units_processed -= 1
                 elif not self._file_based:
-                    file_lumis = set(map(tuple, files_info[file][1]))
+                    file_lumis = set(files_info[file][1])
                     for (lumi_id, lumi_file, r, l) in file_units:
+                        logger.error('FILE UNITS %s' % file_units)
                         if (r, l) not in file_lumis:
+                            logger.error('FILE LUMIS %s' % file_lumis)
                             unit_update.append((unit.FAILED, lumi_id))
                             units_processed -= 1
 

--- a/lobster/core/unit.py
+++ b/lobster/core/unit.py
@@ -549,8 +549,8 @@ class UnitStore:
                 # update files in the workflow
                 if len(file_updates) > 0:
                     self.db.executemany("""update files_{0} set
-                        units_running=(select count(*) from units_{0} where status==1 and file=files_{0}.id),
-                        units_done=(select count(*) from units_{0} where status==2 and file=files_{0}.id),
+                        units_running=(select count(*) from units_{0} where file=files_{0}.id and status==1),
+                        units_done=(select count(*) from units_{0} where file=files_{0}.id and status==2),
                         events_read=(events_read + ?),
                         skipped=(skipped + ?)
                         where id=?""".format(dset),

--- a/lobster/core/unit.py
+++ b/lobster/core/unit.py
@@ -236,12 +236,10 @@ class UnitStore:
             foreign key(task) references tasks(id),
             foreign key(file) references files_{0}(id))""".format(label))
 
-        self.db.execute(
-            "create index if not exists index_filename_{0} on files_{0}(filename)".format(label))
-        self.db.execute(
-            "create index if not exists index_events_{0} on units_{0}(run, lumi)".format(label))
-        self.db.execute(
-            "create index if not exists index_files_{0} on units_{0}(file)".format(label))
+        self.db.execute("create index if not exists index_filename_{0} on files_{0}(filename)".format(label))
+        self.db.execute("create index if not exists index_events_{0} on units_{0}(run, lumi)".format(label))
+        self.db.execute("create index if not exists index_files_{0} on units_{0}(file)".format(label))
+        self.db.execute("create index if not exists index_task_{0} on units_{0}(task)".format(label))
         self.db.commit()
 
         self.register_files(dataset_info.files, label, unique_args)

--- a/test/test_se.py
+++ b/test/test_se.py
@@ -69,6 +69,7 @@ class TestLocalPermissions(TestSE):
     def runTest(self):
         self.permissions('file://' + self.workdir)
 
+
 if 'LOBSTER_SKIP_HADOOP' not in os.environ:
     class TestHadoop(TestSE):
 
@@ -123,6 +124,7 @@ class TestFailure(TestSE):
 
     def runTest(self):
         self.query(['file:///fuckup', 'file://' + self.workdir])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Supersedes #320 and #526.

Fixes #319, closes #320, closes #526.

# Content

I went through `unit.py` and looked at all the where clauses to find the following worthwhile to add in terms of indices:

* units should be indexed on (file, status)
* tasks should be indexed on (workflow, status)
* workflows should be indexed on (label,)

In addition, I think that @annawoodard's work from earlier this year greatly simplifies and lessens SQLite queries while creating tasks, so I rebased it on top of the indices.

# Before changes

![tasks running](https://cloud.githubusercontent.com/assets/2151261/20479715/8bd54992-afdf-11e6-8283-38dcd4416626.png)
![time split](https://cloud.githubusercontent.com/assets/2151261/20479722/8e2e1aca-afdf-11e6-8f0c-29311c7eea33.png)


# After changes

![tasks](https://cloud.githubusercontent.com/assets/2151261/20479660/54801238-afdf-11e6-90f5-e8ea19701eb2.png)
![time split](https://cloud.githubusercontent.com/assets/2151261/20479663/57d8dc12-afdf-11e6-851c-7c8f65748e41.png)

# My observations

While these two sets of plots are not directly comparable since the "before" has a higher load, it is notable that *what* we spend our time on for a comparable load has shifted away from the database handling to dealing with the processing of tasks of itself.

@WenzhaoLi more testing would be greatly appreciated. Also some verification that with the simplified database handling nothing changed…