### PR TITLE
Fail when sourcing the environment fails.

### DIFF
--- a/docs/monitor.rst
+++ b/docs/monitor.rst
@@ -46,6 +46,7 @@ Code  Reason
 172   Failed to find old releasetop
 173   Failed to create new release area
 174   `cmsenv` failure
+175   Failed to source the environment (may be parrot related)
 179   Stagein failure
 180   Prologue failure
 185   Failed to run command

--- a/lobster/core/data/wrapper.sh
+++ b/lobster/core/data/wrapper.sh
@@ -125,12 +125,12 @@ elif [ ! \( -f "/cvmfs/cms.cern.ch/cmsset_default.sh" \
 fi
 
 log "sourcing CMS setup"
-source /cvmfs/cms.cern.ch/cmsset_default.sh
+source /cvmfs/cms.cern.ch/cmsset_default.sh || exit_on_error $? 175 "Failed to source CMS"
 
 if [ -z "$LOBSTER_PROXY_INFO" -o \( -z "$LOBSTER_LCG_CP" -a -z "$LOBSTER_GFAL_COPY" \) ]; then
 	log "sourcing OSG setup"
 	slc=$(egrep "Red Hat Enterprise|Scientific|CentOS" /etc/redhat-release | sed 's/.*[rR]elease \([0-9]*\).*/\1/')
-	source /cvmfs/oasis.opensciencegrid.org/osg-software/osg-wn-client/"$LOBSTER_OSG_VERSION"/current/el$slc-$(uname -m)/setup.sh
+	source /cvmfs/oasis.opensciencegrid.org/osg-software/osg-wn-client/"$LOBSTER_OSG_VERSION"/current/el$slc-$(uname -m)/setup.sh || exit_on_error $? 175 "Failed to source OSG"
 
 	[ -z "$LOBSTER_LCG_CP" ] && export LOBSTER_LCG_CP=$(command -v lcg-cp)
 	[ -z "$LOBSTER_GFAL_COPY" ] && export LOBSTER_GFAL_COPY=$(command -v gfal-copy)


### PR DESCRIPTION
Otherwise, these tasks fail down the line, e.g., with stage-in/out errors.