### PR TITLE
Send email to user when proxy is going to expire within 24 hours.

### DIFF
--- a/lobster/cmssw/proxy.py
+++ b/lobster/cmssw/proxy.py
@@ -60,3 +60,6 @@ class Proxy(Configurable):
 
     def expires(self):
         return int(time.time()) + self.__proxy.getTimeLeft()
+
+    def time_left(self):
+        return self.__proxy.getTimeLeft()

--- a/lobster/commands/process.py
+++ b/lobster/commands/process.py
@@ -277,7 +277,9 @@ class Process(Command, util.Timing):
                 if self.config.advanced.proxy:
                     expiry = self.config.advanced.proxy.expires()
                     proxy_time_left = self.config.advanced.proxy.time_left()
-                    if proxy_time_left < 200 * 3600 & not proxy_email_sent:  
+                    if proxy_time_left >= 24 * 3600: 
+                        proxy_email_sent = False
+                    if proxy_time_left < 24 * 3600 and not proxy_email_sent:  
                         util.sendemail("Your proxy is about to expire.\n" + "Timeleft: " + str(datetime.timedelta(seconds = proxy_time_left)), self.config)
                         proxy_email_sent = True
 

--- a/lobster/commands/process.py
+++ b/lobster/commands/process.py
@@ -242,6 +242,7 @@ class Process(Command, util.Timing):
             if 'wall_time' not in constraints:
                 self.queue.activate_fast_abort_category(category.name, abort_multiplier)
 
+        proxy_email_sent = False
         while not self.source.done():
             with self.measure('status'):
                 tasks_left = self.source.tasks_left()
@@ -276,10 +277,10 @@ class Process(Command, util.Timing):
                 if self.config.advanced.proxy:
                     expiry = self.config.advanced.proxy.expires()
                     proxy_time_left = self.config.advanced.proxy.time_left()
-                    if proxy_time_left < 24 * 3600:
-                        _ = proxy_time_left
-                        util.sendemail("Your proxy is about to expire.\n Timeleft {0}:{1:02}\n".format(_ / 3600, _ / 60) + str(_), self.config)
-                    
+                    if proxy_time_left < 200 * 3600 & not proxy_email_sent:  
+                        util.sendemail("Your proxy is about to expire.\n" + "Timeleft: " + str(datetime.timedelta(seconds = proxy_time_left)), self.config)
+                        proxy_email_sent = True
+
                 for category, cmd, id, inputs, outputs, env, dir in tasks:
                     task = wq.Task(cmd)
                     task.specify_category(category)

--- a/lobster/commands/process.py
+++ b/lobster/commands/process.py
@@ -277,10 +277,10 @@ class Process(Command, util.Timing):
                 if self.config.advanced.proxy:
                     expiry = self.config.advanced.proxy.expires()
                     proxy_time_left = self.config.advanced.proxy.time_left()
-                    if proxy_time_left >= 24 * 3600: 
+                    if proxy_time_left >= 24 * 3600:
                         proxy_email_sent = False
-                    if proxy_time_left < 24 * 3600 and not proxy_email_sent:  
-                        util.sendemail("Your proxy is about to expire.\n" + "Timeleft: " + str(datetime.timedelta(seconds = proxy_time_left)), self.config)
+                    if proxy_time_left < 24 * 3600 and not proxy_email_sent:
+                        util.sendemail("Your proxy is about to expire.\n" + "Timeleft: " + str(datetime.timedelta(seconds=proxy_time_left)), self.config)
                         proxy_email_sent = True
 
                 for category, cmd, id, inputs, outputs, env, dir in tasks:

--- a/lobster/commands/process.py
+++ b/lobster/commands/process.py
@@ -275,7 +275,11 @@ class Process(Command, util.Timing):
                 expiry = None
                 if self.config.advanced.proxy:
                     expiry = self.config.advanced.proxy.expires()
-
+                    proxy_time_left = self.config.advanced.proxy.time_left()
+                    if proxy_time_left < 24 * 3600:
+                        _ = proxy_time_left
+                        util.sendemail("Your proxy is about to expire.\n Timeleft {0}:{1:02}\n".format(_ / 3600, _ / 60) + str(_), self.config)
+                    
                 for category, cmd, id, inputs, outputs, env, dir in tasks:
                     task = wq.Task(cmd)
                     task.specify_category(category)


### PR DESCRIPTION
Send email to user when proxy is going to expire within 24 hours.
The email will only be sent once. But every time user renews the proxy, the email will be reset. Which means, if the proxy drops to 24 hours again, another email will be sent, and so forth. 