### PR TITLE
Sandbox cleanup and other fixes

### DIFF
--- a/lobster/cmssw/sandbox.py
+++ b/lobster/cmssw/sandbox.py
@@ -51,7 +51,7 @@ class Sandbox(lobster.core.Sandbox):
         """Returns a filename for a given release top, i.e., the file system
         path of a release.
         """
-        p = os.path.abspath(os.path.expandvars(os.path.expanduser(rel)))
+        p = os.path.abspath(os.path.expandvars(os.path.expanduser(indir)))
         version = arch.split('_', 1)[0]
         return "sandbox-{r}-{v}-{d}.tar.bz2".format(r=rel, v=version, d=hashlib.sha1(p).hexdigest()[:7])
 

--- a/lobster/cmssw/sandbox.py
+++ b/lobster/cmssw/sandbox.py
@@ -115,7 +115,7 @@ class Sandbox(lobster.core.Sandbox):
         subdirs += [os.path.join('src', incl) for incl in self.include]
 
         for (path, dirs, files) in os.walk(os.path.join(indir, 'src')):
-            for subdir in ['data', 'python']:
+            for subdir in ['data', 'python', 'interface']:
                 if subdir in dirs:
                     rtpath = os.path.join(os.path.relpath(path, indir), subdir)
                     subdirs.append(rtpath)

--- a/lobster/commands/validate.py
+++ b/lobster/commands/validate.py
@@ -5,6 +5,9 @@ from lobster.core.command import Command
 from lobster.core.unit import UnitStore
 
 
+logger = logging.getLogger('lobster.validate')
+
+
 class Validate(Command):
 
     @property
@@ -17,65 +20,86 @@ class Validate(Command):
         argparser.add_argument('--delete-merged', action='store_true', dest='delete_merged', default=False,
                                help='remove intermediate files that have been merged')
 
-    def run(self, args):
-        config = args.config
+    def print_stats(self, stats):
+        logger.info('{0:<20} {1:>20} {2:>20} {3:>23}'.format('label',
+                                                             '# of bad files',
+                                                             '# of merged files',
+                                                             '# of uncleaned files'))
+        logger.info('-' * 86)
+        for label, (fails, merges, uncleaned) in stats.items():
+            if fails > 0 or merges > 0 or uncleaned > 0:
+                logger.info('{0:<20} {1:>20} {2:>20} {3:>23}'.format(label, fails, merges, uncleaned))
 
-        logger = logging.getLogger('lobster.validate')
+        logger.info('-' * 86)
+        logger.info('{0:<20} {1:>20} {2:>20} {3:>23}'.format('total',
+                                                             sum(f for f, m, c in stats.values()),
+                                                             sum(m for f, m, c in stats.values()),
+                                                             sum(c for f, m, c in stats.values())))
 
-        store = UnitStore(config)
-
-        stats = dict((w.label, [0, 0]) for w in config.workflows)
-
+    def process_workflow(self, store, stats, wflow):
+        files = set(fs.ls(wflow.label))
+        delete = []
+        merged = []
         missing = []
-        for wflow in config.workflows:
-            logger.info('validating output files for {0}'.format(wflow.label))
 
-            files = set(fs.ls(wflow.label))
-            delete = []
+        cleaned = any(w.cleanup_input for w in wflow.dependents)
 
-            for task, task_type in store.failed_tasks(wflow.label):
-                for _, filename in wflow.get_outputs(task):
-                    if filename in files:
-                        logger.info(
-                            "found output from failed task: {0}".format(filename))
-                        stats[wflow.label][0] += 1
-                        if not args.dry_run:
-                            delete.append(filename)
+        for task, task_type in store.failed_tasks(wflow.label):
+            for _, filename in wflow.get_outputs(task):
+                if filename in files:
+                    logger.info("found output from failed task: {0}".format(filename))
+                    stats[wflow.label][0] += 1
+                    delete.append(filename)
 
-            for task, task_type in store.merged_tasks(wflow.label):
-                for _, filename in wflow.get_outputs(task):
-                    if filename in files:
-                        logger.info(
-                            "found output from intermediate merged task: {0}".format(filename))
-                        stats[wflow.label][1] += 1
-                        if not args.dry_run and args.delete_merged:
-                            delete.append(filename)
+        for task, task_type in store.merged_tasks(wflow.label):
+            for _, filename in wflow.get_outputs(task):
+                if filename in files:
+                    logger.info("found output from intermediate merged task: {0}".format(filename))
+                    stats[wflow.label][1] += 1
+                    merged.append(filename)
 
-            for fn in delete:
-                fs.remove(fn)
-
+        if cleaned:
+            for w in wflow.dependents:
+                if not w.cleanup_input:
+                    continue
+                if store.unfinished_units(w.label) == 0:
+                    for fn in files:
+                        logger.warning('found output from tasks that should have been cleaned up: {}'.format(fn))
+                    stats[wflow.label][2] += len(files)
+                    delete.extend(files)
+            else:
+                logger.error("can't validate workflow {}, as its dependents have not completed and cleaned it up".format(wflow.label))
+        else:
             for task, task_type in store.successful_tasks(wflow.label):
                 for _, filename in wflow.get_outputs(task):
                     if filename not in files:
                         missing.append(task)
-                        logger.warning(
-                            'output file is missing for {0}'.format(task))
+                        logger.warning('output file is missing for {0}'.format(task))
+
+        return delete, merged, missing
+
+    def run(self, args):
+        store = UnitStore(args.config)
+        stats = dict((w.label, [0, 0, 0]) for w in args.config.workflows)
+
+        missing = []
+        for wflow in args.config.workflows:
+            logger.info('validating output files for {0}'.format(wflow.label))
+
+            delete, merged, missed = self.process_workflow(store, stats, wflow)
+            missing += missed
+
+            if not args.dry_run:
+                fs.remove(*delete)
+                if args.delete_merged:
+                    fs.remove(*merged)
 
         logger.info('finished validating')
+
         if sum(sum(stats.values(), [])) == 0:
             logger.info('no files found to cleanup')
         else:
-            logger.info('{0:<20} {1:>20} {2:>20}'.format(
-                'label', '# of bad files', '# of merged files'))
-            logger.info('-' * 62)
-            for label, (fails, merges) in stats.items():
-                if fails > 0 or merges > 0:
-                    logger.info('{0:<20} {1:>20} {2:>20}'.format(
-                        label, fails, merges))
-
-            logger.info('-' * 62)
-            logger.info('{0:<20} {1:>20} {2:>20}'.format('total', sum(
-                f for f, m in stats.values()), sum(m for f, m in stats.values())))
+            self.print_stats(stats)
 
         if len(missing) > 0:
             if not args.dry_run:

--- a/lobster/core/data/wrapper.sh
+++ b/lobster/core/data/wrapper.sh
@@ -148,8 +148,6 @@ rel=$(echo CMSSW_*)
 arch=$(ls $rel/.SCRAM/|grep slc) || exit_on_error $? 171 "Failed to determine SL release!"
 old_release_top=$(awk -F= '/RELEASETOP/ {print $2}' $rel/.SCRAM/slc*/Environment) || exit_on_error $? 172 "Failed to determine old releasetop!"
 
-export SCRAM_ARCH=$arch
-
 log "creating new release $rel"
 mkdir lobster_release_tmp || exit_on_error $? 173 "Failed to create temporary directory"
 cd lobster_release_tmp
@@ -157,12 +155,11 @@ scramv1 project -f CMSSW $rel || exit_on_error $? 173 "Failed to create new rele
 new_release_top=$(awk -F= '/RELEASETOP/ {print $2}' $rel/.SCRAM/slc*/Environment)
 cd $rel
 log "preparing sandbox release $rel"
-for i in bin cfipython config lib module python src; do
+for i in bin cfipython lib module python src; do
 	rm -rf "$i"
 	mv "$basedir/$rel/$i" .
 	# ls -lR $i
 done
-
 
 log "fixing python paths"
 for f in $(find -iname __init__.py); do

--- a/lobster/core/data/wrapper.sh
+++ b/lobster/core/data/wrapper.sh
@@ -140,32 +140,18 @@ log "env" "environment after sourcing startup scripts" env
 log "proxy" "proxy information" env X509_USER_PROXY=proxy voms-proxy-info
 log "dir" "working directory at startup" ls -l
 
-tar xjf sandbox.tar.bz2 || exit_on_error $? 170 "Failed to unpack sandbox!"
+log "creating new release $LOBSTER_CMSSW_VERSION"
+
+scramv1 project -f CMSSW $LOBSTER_CMSSW_VERSION || exit_on_error $? 173 "Failed to create new release"
+arch=$(ls $LOBSTER_CMSSW_VERSION/.SCRAM/|grep slc) || exit_on_error $? 171 "Failed to determine SL release!"
+
+log "unpacking sandbox-${LOBSTER_CMSSW_VERSION}-${arch%%_*}.tar.bz2"
+for d in bin cfipython lib python src; do
+	tar xjf sandbox-${LOBSTER_CMSSW_VERSION}-${arch%%_*}.tar.bz2 $LOBSTER_CMSSW_VERSION/$d || exit_on_error $? 170 "Failed to unpack sandbox!"
+done
 
 basedir=$PWD
-
-rel=$(echo CMSSW_*)
-arch=$(ls $rel/.SCRAM/|grep slc) || exit_on_error $? 171 "Failed to determine SL release!"
-old_release_top=$(awk -F= '/RELEASETOP/ {print $2}' $rel/.SCRAM/slc*/Environment) || exit_on_error $? 172 "Failed to determine old releasetop!"
-
-log "creating new release $rel"
-mkdir lobster_release_tmp || exit_on_error $? 173 "Failed to create temporary directory"
-cd lobster_release_tmp
-scramv1 project -f CMSSW $rel || exit_on_error $? 173 "Failed to create new release"
-new_release_top=$(awk -F= '/RELEASETOP/ {print $2}' $rel/.SCRAM/slc*/Environment)
-cd $rel
-log "preparing sandbox release $rel"
-for i in bin cfipython lib module python src; do
-	rm -rf "$i"
-	mv "$basedir/$rel/$i" .
-	# ls -lR $i
-done
-
-log "fixing python paths"
-for f in $(find -iname __init__.py); do
-	sed -i -e "s@$old_release_top@$new_release_top@" "$f"
-done
-
+cd $LOBSTER_CMSSW_VERSION
 eval $(scramv1 runtime -sh) || exit_on_error $? 174 "The command 'cmsenv' failed!"
 cd "$basedir"
 

--- a/lobster/core/source.py
+++ b/lobster/core/source.py
@@ -373,6 +373,13 @@ class TaskProvider(util.Timing):
                 'gridpack': False
             }
 
+            cmd = 'sh wrapper.sh python task.py parameters.json'
+            env = {
+                'LOBSTER_CVMFS_PROXY': self.__cvmfs_proxy,
+                'LOBSTER_FRONTIER_PROXY': self.__frontier_proxy,
+                'LOBSTER_OSG_VERSION': self.config.advanced.osg_version
+            }
+
             if merge:
                 missing = []
                 infiles = []
@@ -400,12 +407,12 @@ class TaskProvider(util.Timing):
                     logger.debug("skipping task {0} with only one input file!".format(id))
 
                 # takes care of the fields set to None in config
-                wflow.adjust(config, jdir, inputs, outputs, merge, reports=inreports)
+                wflow.adjust(config, env, jdir, inputs, outputs, merge, reports=inreports)
 
                 files = infiles
             else:
                 # takes care of the fields set to None in config
-                wflow.adjust(config, jdir, inputs, outputs, merge, unique=unique_arg)
+                wflow.adjust(config, env, jdir, inputs, outputs, merge, unique=unique_arg)
 
             handler = wflow.handler(id, files, lumis, jdir, merge=merge)
 
@@ -418,13 +425,6 @@ class TaskProvider(util.Timing):
             with open(os.path.join(jdir, 'parameters.json'), 'w') as f:
                 json.dump(config, f, indent=2)
                 f.write('\n')
-
-            cmd = 'sh wrapper.sh python task.py parameters.json'
-            env = {
-                'LOBSTER_CVMFS_PROXY': self.__cvmfs_proxy,
-                'LOBSTER_FRONTIER_PROXY': self.__frontier_proxy,
-                'LOBSTER_OSG_VERSION': self.config.advanced.osg_version
-            }
 
             tasks.append(('merge' if merge else wflow.category.name, cmd, id, inputs, outputs, env, jdir))
 

--- a/lobster/core/unit.py
+++ b/lobster/core/unit.py
@@ -662,9 +662,11 @@ class UnitStore:
 
         return sum(int(math.ceil(ntasks)) for ntasks in rows)
 
-    def unfinished_units(self):
-        cur = self.db.execute(
-            "select sum(units - units_done - units_paused - units_masked) from workflows")
+    def unfinished_units(self, label=None):
+        if label:
+            cur = self.db.execute("select units - units_done - units_paused - units_masked from workflows where label=?", (label,))
+        else:
+            cur = self.db.execute("select sum(units - units_done - units_paused - units_masked) from workflows")
         res = cur.fetchone()[0]
         return 0 if res is None else res
 
@@ -910,7 +912,7 @@ class UnitStore:
         cur = self.db.execute("""
             select id, type
             from tasks
-            where and workflow=? and status=2
+            where workflow=? and status=2
             """, (dset_id,))
 
         return cur

--- a/lobster/core/unit.py
+++ b/lobster/core/unit.py
@@ -556,7 +556,7 @@ class UnitStore:
         if roots is None:
             roots = [w for w in self.config.workflows if not w.parent]
         with self.db:
-            for m in [r.family for r in roots]:
+            for m in sum([list(r.family()) for r in roots], []):
                 self.db.execute("update workflows set merged=0 where label=?", (m.label,))
                 self.update_workflow_stats(m.label)
 

--- a/lobster/core/workflow.py
+++ b/lobster/core/workflow.py
@@ -142,10 +142,12 @@ class Workflow(Configurable):
         merge_size : str
             Activates output file merging when set.  Accepts the suffixes
             *k*, *m*, *g* for kilobyte, megabyte, …
-        sandbox : Sandbox
-            The sandbox to use.  Currently can be either a
-            :class:`~lobster.cmssw.Sandbox` or a
-            :class:`~lobster.core.Sandbox`.
+        sandbox : Sandbox or list of Sandbox
+            The sandbox(es) to use.  Currently can be a
+            :class:`~lobster.cmssw.Sandbox`.  When multiple sandboxes are
+            used, one sandbox per computing architecture to be run on is
+            expected, containing the same release, and an
+            :class:`ValueError` will be raised otherwise.
         command : str
             Which executable to run (for non-CMSSW workflows)
         extra_inputs : list
@@ -376,11 +378,11 @@ class Workflow(Configurable):
             version, arch, sandbox = box.package(basedirs, workdir)
             versions.add(version)
             if arch in archs:
-                raise AttributeError("More than one sandbox supplied for the same architecture!")
+                raise ValueError("More than one sandbox supplied for the same architecture!")
             archs.add(arch)
             self.sandboxes.append(sandbox)
         if len(versions) > 1:
-            raise AttributeError("More than one CMSSW version specified!")
+            raise ValueError("More than one CMSSW version specified!")
         self.version = versions.pop()
 
         self.copy_inputs(basedirs)

--- a/lobster/se.py
+++ b/lobster/se.py
@@ -230,12 +230,11 @@ class Hadoop(StorageElement):
         return self.__c.stat([path])['permission']
 
     def remove(self, *paths):
-        for p in paths:
-            try:
-                for data in self.__c.delete([p]):
-                    pass
-            except snakebite.errors.FileNotFoundException:
+        try:
+            for data in self.__c.delete(list(paths)):
                 pass
+        except snakebite.errors.FileNotFoundException:
+            pass
 
 
 class Chirp(StorageElement):

--- a/test/data/sandbox/CMSSW_1_2_3/.SCRAM/Environment
+++ b/test/data/sandbox/CMSSW_1_2_3/.SCRAM/Environment
@@ -1,1 +1,2 @@
-Useless.
+foo=bar
+SCRAM_PROJECTVERSION=CMSSW_2_3_4

--- a/test/data/sandbox/CMSSW_1_2_3/.SCRAM/slc1_234
+++ b/test/data/sandbox/CMSSW_1_2_3/.SCRAM/slc1_234
@@ -1,0 +1,1 @@
+Useless.

--- a/test/test_cmssw_sandbox.py
+++ b/test/test_cmssw_sandbox.py
@@ -18,16 +18,18 @@ class TestSandbox(unittest.TestCase):
     def test_localrt(self):
         os.environ['LOCALRT'] = 'data/sandbox/CMSSW_1_2_3'
         sandbox = lobster.cmssw.sandbox.Sandbox()
-        version, box = sandbox.package([os.path.dirname(__file__)], self.workdir)
-        assert version == 'CMSSW_1_2_3'
+        version, arch, box = sandbox.package([os.path.dirname(__file__)], self.workdir)
+        assert version == 'CMSSW_2_3_4'
+        assert arch == 'slc1_234'
 
     def test_version(self):
         sandbox = lobster.cmssw.sandbox.Sandbox(release='data/sandbox/CMSSW_1_2_3')
-        version, box = sandbox.package([os.path.dirname(__file__)], self.workdir)
-        assert version == 'CMSSW_1_2_3'
+        version, arch, box = sandbox.package([os.path.dirname(__file__)], self.workdir)
+        assert version == 'CMSSW_2_3_4'
+        assert arch == 'slc1_234'
 
     def test_include(self):
         sandbox = lobster.cmssw.sandbox.Sandbox(release='data/sandbox/CMSSW_1_2_3', include=['Foo/mydir'])
-        version, box = sandbox.package([os.path.dirname(__file__)], self.workdir)
+        version, arch, box = sandbox.package([os.path.dirname(__file__)], self.workdir)
         files = [f.name for f in tarfile.open(box)]
-        assert 'CMSSW_1_2_3/src/Foo/mydir' in files
+        assert 'CMSSW_2_3_4/src/Foo/mydir' in files


### PR DESCRIPTION
I wanted to put this out here… included:

* clean up of sandbox handling. We had this somewhat overcomplicated, with the actual release area on the worker hidden away, and the one in the working directory of the wrapper cleaned out. In addition, not all variables need to be set right away and we packed too much stuff.
* Lobster should now be able to run on release areas that are not identical to the release used (when created with `scram project -d CMSSW_X_Y_Z_i_am_doing_that CMSSW CMSSW_X_Y_Z`)
* Support for multiple sandboxes, one per release architecture (allows to run on RH6 + RH7)
* Have validation take cleaned up files into account

Tested on Singularity, where (miraculously) the right arch is picked (RH6). I've been running like this for ~10 days, no problems so far. 

Note:

* a1c61b3 fixes #538