### PR TITLE
Add paper style and small plotting fixes

### DIFF
--- a/lobster/commands/data/category.html
+++ b/lobster/commands/data/category.html
@@ -20,8 +20,11 @@
 
         <script src="http://code.jquery.com/jquery-1.9.1.min.js"></script>
         <script>
-            function src_replace(sel, a, b) {
-                $(sel).attr("src", function(idx, src) {
+            function src_replace(cls, a, b) {
+                $("img." + cls).attr("src", function(idx, src) {
+                    return src.replace(a, b);
+                });
+                $("img." + cls).closest("a").attr("href", function(idx, src) {
                     return src.replace(a, b);
                 });
             };
@@ -60,7 +63,7 @@
                 });
 
                 $("a#mergehist").bind('click', function() {
-                    src_replace("img.merge", "-prof", "-hist");
+                    src_replace("merge", "-prof", "-hist");
                     $("span#mergehist.left").removeClass("depressed");
                     $("span#mergehist.left").addClass("pressed");
                     $("span#mergehist.right").removeClass("pressed");
@@ -68,7 +71,7 @@
                     return false;
                 });
                 $("a#mergeprof").bind('click', function() {
-                    src_replace("img.merge", "-hist", "-prof");
+                    src_replace("merge", "-hist", "-prof");
                     $("span#mergehist.left").removeClass("pressed");
                     $("span#mergehist.left").addClass("depressed");
                     $("span#mergehist.right").removeClass("depressed");
@@ -77,7 +80,7 @@
                 });
 
                 $("a#goodhist").bind('click', function() {
-                    src_replace("img.good", "-prof", "-hist");
+                    src_replace("good", "-prof", "-hist");
                     $("span#goodhist.left").removeClass("depressed");
                     $("span#goodhist.left").addClass("pressed");
                     $("span#goodhist.right").removeClass("pressed");
@@ -85,7 +88,7 @@
                     return false;
                 });
                 $("a#goodprof").bind('click', function() {
-                    src_replace("img.good", "-hist", "-prof");
+                    src_replace("good", "-hist", "-prof");
                     $("span#goodhist.right").removeClass("depressed");
                     $("span#goodhist.right").addClass("pressed");
                     $("span#goodhist.left").removeClass("pressed");

--- a/lobster/commands/data/category.html
+++ b/lobster/commands/data/category.html
@@ -7,11 +7,11 @@
         <link rel="stylesheet" href="../styles.css">
 
         {% macro label_wrapper(img_name, label) %}
-        <li><a class="workflow" href="{{ img_name }}"><img alt="{{ label }}"
+        <li><a class="workflow" href="{{ img_name }}.pdf"><img alt="{{ label }}"
                     {% for k, v in kwargs.iteritems() %}
                         {{ k }}="{{ v }}"
                     {% endfor %}
-                src="{{ img_name }}"/>
+                src="{{ img_name }}.png"/>
                 <span class="text-content"><span>
                     {{ label }}
                 </span></span>
@@ -172,17 +172,17 @@
         <h1 id="navtasks">Task Summary</h1>
         <div class="sidebar">
         {% if good_tasks or bad_tasks %}
-            <a class="workflow" href="time-pie.png"><img class="side" alt="" src="time-pie.png"/></a>
+            <a class="workflow" href="time-pie.pdf"><img class="side" alt="" src="time-pie.png"/></a>
         {% endif %}
         </div>
         <div class="maincontent">
-            <a class="workflow" href="tasks-plot.png"><img alt="" src="tasks-plot.png"/></a>
+            <a class="workflow" href="tasks-plot.pdf"><img alt="" src="tasks-plot.png"/></a>
         {% if good_tasks or bad_tasks %}
-            <a class="workflow" href="all-tasks-hist.png"><img alt="" src="all-tasks-hist.png"/></a>
+            <a class="workflow" href="all-tasks-hist.pdf"><img alt="" src="all-tasks-hist.png"/></a>
         {% if good_tasks %}
             <h3>Efficiency</h3>
-            <a href="cpu-wall-hist.png"><img alt="" src="cpu-wall-hist.png"/></a>
-            <a href="cpu-wall-int-hist.png"><img alt="" src="cpu-wall-int-hist.png"/></a>
+            <a href="cpu-wall-hist.pdf"><img alt="" src="cpu-wall-hist.png"/></a>
+            <a href="cpu-wall-int-hist.pdf"><img alt="" src="cpu-wall-int-hist.png"/></a>
         {% endif %}
         {% if good_tasks or bad_tasks %}
 	    <h3>Transfer Protocol Summary</h3>
@@ -211,49 +211,49 @@
         <h2 id="navgood">Successful Tasks</h2>
         {% if good_tasks %}
         <div class="sidebar">
-            <a class="workflow" href="good-time-detail-pie.png"><img class="side" alt="" src="good-time-detail-pie.png"/></a>
+            <a class="workflow" href="good-time-detail-pie.pdf"><img class="side" alt="" src="good-time-detail-pie.png"/></a>
         </div>
         <div class="maincontent">
             <h3>Task Resources Utilized</h3>
-            <a class="workflow" href="good-memory-hist.png"><img alt="" src="good-memory-hist.png"/></a>
-            <a class="workflow" href="good-workdir-footprint-hist.png"><img alt="" src="good-workdir-footprint-hist.png"/></a>
-            <a class="workflow" href="good-cores-hist.png"><img alt="" src="good-cores-hist.png"/></a>
-            <a class="workflow" href="good-network-bandwidth-prof.png"><img alt="" src="good-network-bandwidth-prof.png"/></a>
-            <a class="workflow" href="good-exe-efficiency-hist.png"><img alt="" src="good-exe-efficiency-hist.png"/></a>
-            <a class="workflow" href="good-exhausted-attempts-prof.png"><img alt="" src="good-exhausted-attempts-prof.png"/></a>
+            <a class="workflow" href="good-memory-hist.pdf"><img alt="" src="good-memory-hist.png"/></a>
+            <a class="workflow" href="good-workdir-footprint-hist.pdf"><img alt="" src="good-workdir-footprint-hist.png"/></a>
+            <a class="workflow" href="good-cores-hist.pdf"><img alt="" src="good-cores-hist.png"/></a>
+            <a class="workflow" href="good-network-bandwidth-prof.pdf"><img alt="" src="good-network-bandwidth-prof.png"/></a>
+            <a class="workflow" href="good-exe-efficiency-hist.pdf"><img alt="" src="good-exe-efficiency-hist.png"/></a>
+            <a class="workflow" href="good-exhausted-attempts-prof.pdf"><img alt="" src="good-exhausted-attempts-prof.png"/></a>
             <h3>Task Resources Allocated</h3>
-            <a class="workflow" href="good-allocated-memory-prof.png"><img alt="" src="good-allocated-memory-prof.png"/></a>
-            <a class="workflow" href="good-allocated-disk-prof.png"><img alt="" src="good-allocated-disk-prof.png"/></a>
-            <a class="workflow" href="good-allocated-cores-prof.png"><img alt="" src="good-allocated-cores-prof.png"/></a>
-            <a class="workflow" href="good-tasksize-prof.png"><img alt="" src="good-tasksize-prof.png"/></a>
+            <a class="workflow" href="good-allocated-memory-prof.pdf"><img alt="" src="good-allocated-memory-prof.png"/></a>
+            <a class="workflow" href="good-allocated-disk-prof.pdf"><img alt="" src="good-allocated-disk-prof.png"/></a>
+            <a class="workflow" href="good-allocated-cores-prof.pdf"><img alt="" src="good-allocated-cores-prof.png"/></a>
+            <a class="workflow" href="good-tasksize-prof.pdf"><img alt="" src="good-tasksize-prof.png"/></a>
             <h3>Task Timing</h3>
             <p>
                 <span id="goodhist" class="button left pressed"><a href="#" id="goodhist">statistics</a></span><span id="goodhist" class="button right depressed"><a href="#" id="goodprof">profile</a></span>
                 <span id="goodmore" class="button depressed"><a href="#" id="goodmore">show timeline breakdown</a></span>
             </p>
             <div class="good more"><ul class="img-list">
-                {{ label_wrapper('good-eviction-hist.png', 'Time lost to eviction', class="good") }}
-                {{ label_wrapper('good-exhaustion-hist.png', 'Time lost to exceeding allocated resources', class="good") }}
+                {{ label_wrapper('good-eviction-hist', 'Time lost to eviction', class="good") }}
+                {{ label_wrapper('good-exhaustion-hist', 'Time lost to exceeding allocated resources', class="good") }}
             </ul></div>
             <div><ul class="img-list">
-                {{ label_wrapper('good-runtime-hist.png', 'Time from wrapper start to processing end', class='good') }}
-                {{ label_wrapper('good-overhead-hist.png', 'Time from wrapper start to begin processing the first event', class='good') }}
+                {{ label_wrapper('good-runtime-hist', 'Time from wrapper start to processing end', class='good') }}
+                {{ label_wrapper('good-overhead-hist', 'Time from wrapper start to begin processing the first event', class='good') }}
             </ul></div>
             <div class="good more"><ul class="img-list">
-                {{ label_wrapper('good-transfer-in-hist.png', 'Time to transfer input files', class='good') }}
-                {{ label_wrapper('good-startup-hist.png', 'Time between completing the input file transfer and starting the wrapper', class='good') }}
-                {{ label_wrapper('good-stage-in-hist.png', 'Time to stage in all additional input files', class='good more') }}
-                {{ label_wrapper('good-prologue-hist.png', 'Time to run the prologue command', class='good more') }}
-                {{ label_wrapper('good-setup-release-hist.png', 'Time to set up release and initialize cms environment', class='good') }}
+                {{ label_wrapper('good-transfer-in-hist', 'Time to transfer input files', class='good') }}
+                {{ label_wrapper('good-startup-hist', 'Time between completing the input file transfer and starting the wrapper', class='good') }}
+                {{ label_wrapper('good-stage-in-hist', 'Time to stage in all additional input files', class='good more') }}
+                {{ label_wrapper('good-prologue-hist', 'Time to run the prologue command', class='good more') }}
+                {{ label_wrapper('good-setup-release-hist', 'Time to set up release and initialize cms environment', class='good') }}
             </ul></div>
             <div><ul class="img-list">
-                {{ label_wrapper('good-processing-hist.png', 'Time the executable took to run', class='good') }}
+                {{ label_wrapper('good-processing-hist', 'Time the executable took to run', class='good') }}
             </ul></div>
             <div class="good more"><ul class="img-list">
-                {{ label_wrapper('good-epilogue-hist.png', 'Time to run the epilogue command', class='good more') }}
-                {{ label_wrapper('good-stage-out-hist.png', 'Time to stage out all output files', class='good more') }}
-                {{ label_wrapper('good-transfer-out-wait-hist.png', 'Time between stageout completion and WQ task.receive_output_start', class='good more') }}
-                {{ label_wrapper('good-transfer-out-wq-hist.png', 'Time between WQ task.receive_output_start and task.receive_output_finish', class='good more') }}
+                {{ label_wrapper('good-epilogue-hist', 'Time to run the epilogue command', class='good more') }}
+                {{ label_wrapper('good-stage-out-hist', 'Time to stage out all output files', class='good more') }}
+                {{ label_wrapper('good-transfer-out-wait-hist', 'Time between stageout completion and WQ task.receive_output_start', class='good more') }}
+                {{ label_wrapper('good-transfer-out-wq-hist', 'Time between WQ task.receive_output_start and task.receive_output_finish', class='good more') }}
             </ul></div>
         </div>
         {% else %}
@@ -263,44 +263,44 @@
         <h2 id="navmerge">Merge tasks</h2>
         {% if merge_tasks %}
         <div class="sidebar">
-            <a class="workflow" href="merge-time-detail-pie.png"><img class="side" alt="" src="merge-time-detail-pie.png"/></a>
+            <a class="workflow" href="merge-time-detail-pie.pdf"><img class="side" alt="" src="merge-time-detail-pie.png"/></a>
         </div>
         <div class="maincontent">
             <h3>Task Resources</h3>
-            <a class="workflow" href="merge-memory-hist.png"><img alt="" src="merge-memory-hist.png"/></a>
-            <a class="workflow" href="merge-workdir-footprint-hist.png"><img alt="" src="merge-workdir-footprint-hist.png"/></a>
-            <a class="workflow" href="merge-cores-hist.png"><img alt="" src="merge-cores-hist.png"/></a>
-            <a class="workflow" href="merge-network-bandwidth-prof.png"><img alt="" src="merge-network-bandwidth-prof.png"/></a>
-            <a class="workflow" href="merge-exe-efficiency-hist.png"><img alt="" src="merge-exe-efficiency-hist.png"/></a>
-            <a class="workflow" href="merge-exhausted-attempts-prof.png"><img alt="" src="merge-exhausted-attempts-prof.png"/></a>
+            <a class="workflow" href="merge-memory-hist.pdf"><img alt="" src="merge-memory-hist.png"/></a>
+            <a class="workflow" href="merge-workdir-footprint-hist.pdf"><img alt="" src="merge-workdir-footprint-hist.png"/></a>
+            <a class="workflow" href="merge-cores-hist.pdf"><img alt="" src="merge-cores-hist.png"/></a>
+            <a class="workflow" href="merge-network-bandwidth-prof.pdf"><img alt="" src="merge-network-bandwidth-prof.png"/></a>
+            <a class="workflow" href="merge-exe-efficiency-hist.pdf"><img alt="" src="merge-exe-efficiency-hist.png"/></a>
+            <a class="workflow" href="merge-exhausted-attempts-prof.pdf"><img alt="" src="merge-exhausted-attempts-prof.png"/></a>
             <h3>Task Timing</h3>
             <p>
                 <span id="mergehist" class="button left pressed"><a href="#" id="mergehist">statistics</a></span><span id="mergehist" class="button right depressed"><a href="#" id="mergeprof">profile</a></span>
                 <span id="mergemore" class="button depressed"><a href="#" id="mergemore">show timeline breakdown</a></span>
             </p>
             <div class="merge more"><ul class="img-list">
-                {{ label_wrapper('merge-eviction-hist.png', 'Time lost to eviction', class="merge") }}
-                {{ label_wrapper('merge-exhausted-hist.png', 'Time lost to exceeding allocated resources', class="merge") }}
+                {{ label_wrapper('merge-eviction-hist', 'Time lost to eviction', class="merge") }}
+                {{ label_wrapper('merge-exhausted-hist', 'Time lost to exceeding allocated resources', class="merge") }}
             </ul></div>
             <div><ul class="img-list">
-                {{ label_wrapper('merge-runtime-hist.png', 'Time from wrapper start to processing end', class='merge') }}
-                {{ label_wrapper('merge-overhead-hist.png', 'Time from wrapper start to begin processing the first event', class='merge') }}
+                {{ label_wrapper('merge-runtime-hist', 'Time from wrapper start to processing end', class='merge') }}
+                {{ label_wrapper('merge-overhead-hist', 'Time from wrapper start to begin processing the first event', class='merge') }}
             </ul></div>
             <div class="merge more"><ul class="img-list">
-                {{ label_wrapper('merge-transfer-in-hist.png', 'Time to transfer input files', class='merge') }}
-                {{ label_wrapper('merge-startup-hist.png', 'Time between completing the input file transfer and starting the wrapper', class='merge') }}
-                {{ label_wrapper('merge-stage-in-hist.png', 'Time to stage in all additional input files', class='merge more') }}
-                {{ label_wrapper('merge-prologue-hist.png', 'Time to run the prologue command', class='merge more') }}
-                {{ label_wrapper('merge-setup-release-hist.png', 'Time to set up release and initialize cms environment', class='merge') }}
+                {{ label_wrapper('merge-transfer-in-hist', 'Time to transfer input files', class='merge') }}
+                {{ label_wrapper('merge-startup-hist', 'Time between completing the input file transfer and starting the wrapper', class='merge') }}
+                {{ label_wrapper('merge-stage-in-hist', 'Time to stage in all additional input files', class='merge more') }}
+                {{ label_wrapper('merge-prologue-hist', 'Time to run the prologue command', class='merge more') }}
+                {{ label_wrapper('merge-setup-release-hist', 'Time to set up release and initialize cms environment', class='merge') }}
             </ul></div>
             <div><ul class="img-list">
-                {{ label_wrapper('merge-processing-hist.png', 'Time the executable took to run', class='merge') }}
+                {{ label_wrapper('merge-processing-hist', 'Time the executable took to run', class='merge') }}
             </ul></div>
             <div class="merge more"><ul class="img-list">
-                {{ label_wrapper('merge-epilogue-hist.png', 'Time to run the epilogue command', class='merge more') }}
-                {{ label_wrapper('merge-stage-out-hist.png', 'Time to stage out all output files', class='merge more') }}
-                {{ label_wrapper('merge-transfer-out-wait-hist.png', 'Time between stageout completion and WQ task.receive_output_start', class='merge more') }}
-                {{ label_wrapper('merge-transfer-out-wq-hist.png', 'Time between WQ task.receive_output_start and task.receive_output_finish', class='merge more') }}
+                {{ label_wrapper('merge-epilogue-hist', 'Time to run the epilogue command', class='merge more') }}
+                {{ label_wrapper('merge-stage-out-hist', 'Time to stage out all output files', class='merge more') }}
+                {{ label_wrapper('merge-transfer-out-wait-hist', 'Time between stageout completion and WQ task.receive_output_start', class='merge more') }}
+                {{ label_wrapper('merge-transfer-out-wq-hist', 'Time between WQ task.receive_output_start and task.receive_output_finish', class='merge more') }}
             </ul></div>
         </div>
         {% else %}
@@ -310,18 +310,18 @@
         <h2 id="navbad">Failed tasks</h2>
         {% if bad_tasks %}
         <div class="sidebar">
-            <a class="workflow" href="failed-pie.png"><img class="side" alt="" src="failed-pie.png"/></a>
+            <a class="workflow" href="failed-pie.pdf"><img class="side" alt="" src="failed-pie.png"/></a>
         </div>
         <div class="maincontent">
             <p>A mapping of the exit codes can be found in the <a href="http://lobster.readthedocs.org/en/latest/monitor.html#task-exit-codes">documentation</a>.</p>
             <h3>Failure Modes</h3>
-            <a class="workflow" href="failed-tasks-hist.png"><img alt="" src="failed-tasks-hist.png"/></a>
+            <a class="workflow" href="failed-tasks-hist.pdf"><img alt="" src="failed-tasks-hist.png"/></a>
             <h3>Task Resources</h3>
-            <a class="workflow" href="failed-memory-hist.png"><img alt="" src="failed-memory-hist.png"/></a>
-            <a class="workflow" href="failed-workdir-footprint-hist.png"><img alt="" src="failed-workdir-footprint-hist.png"/></a>
-            <a class="workflow" href="failed-cores-hist.png"><img alt="" src="failed-cores-hist.png"/></a>
-            <a class="workflow" href="failed-network-bandwidth-prof.png"><img alt="" src="failed-network-bandwidth-prof.png"/></a>
-            <a class="workflow" href="failed-exhausted-attempts-prof.png"><img alt="" src="failed-exhausted-attempts-prof.png"/></a>
+            <a class="workflow" href="failed-memory-hist.pdf"><img alt="" src="failed-memory-hist.png"/></a>
+            <a class="workflow" href="failed-workdir-footprint-hist.pdf"><img alt="" src="failed-workdir-footprint-hist.png"/></a>
+            <a class="workflow" href="failed-cores-hist.pdf"><img alt="" src="failed-cores-hist.png"/></a>
+            <a class="workflow" href="failed-network-bandwidth-prof.pdf"><img alt="" src="failed-network-bandwidth-prof.png"/></a>
+            <a class="workflow" href="failed-exhausted-attempts-prof.pdf"><img alt="" src="failed-exhausted-attempts-prof.png"/></a>
             <h3>Task Logs</h3>
             <table class="fancy">
                 <tr>

--- a/lobster/commands/data/index.html
+++ b/lobster/commands/data/index.html
@@ -118,19 +118,19 @@
         <h1 id="navtasks">Task Summary</h1>
         <div class="sidebar">
         {% if good_tasks or bad_tasks %}
-            <a class="workflow" href="all/time-pie.png"><img alt="" src="all/time-pie.png"/></a>
+            <a class="workflow" href="all/time-pie.pdf"><img alt="" src="all/time-pie.png"/></a>
         {% endif %}
         </div>
         <div class="maincontent">
-            <a class="workflow" href="tasks-plot.png"><img alt="" src="tasks-plot.png"/></a>
+            <a class="workflow" href="tasks-plot.pdf"><img alt="" src="tasks-plot.png"/></a>
         {% if good_tasks or bad_tasks %}
-            <a class="workflow" href="all/all-tasks-hist.png"><img alt="" src="all/all-tasks-hist.png"/></a>
+            <a class="workflow" href="all/all-tasks-hist.pdf"><img alt="" src="all/all-tasks-hist.png"/></a>
         {% if good_tasks %}
             <h3>Efficiency</h3>
-            <a href="all/cpu-wall-hist.png"><img alt="" src="all/cpu-wall-hist.png"/></a>
-            <a href="all/cpu-wall-int-hist.png"><img alt="" src="all/cpu-wall-int-hist.png"/></a>
-            <a href="all/cpu-cores-hist.png"><img alt="" src="all/cpu-cores-hist.png"/></a>
-            <a href="all/cpu-cores-int-hist.png"><img alt="" src="all/cpu-cores-int-hist.png"/></a>
+            <a href="all/cpu-wall-hist.pdf"><img alt="" src="all/cpu-wall-hist.png"/></a>
+            <a href="all/cpu-wall-int-hist.pdf"><img alt="" src="all/cpu-wall-int-hist.png"/></a>
+            <a href="all/cpu-cores-hist.pdf"><img alt="" src="all/cpu-cores-hist.png"/></a>
+            <a href="all/cpu-cores-int-hist.pdf"><img alt="" src="all/cpu-cores-int-hist.png"/></a>
         {% endif %}
         {% endif %}
         </div>
@@ -141,23 +141,23 @@
         </div>
         <div class="maincontent">
             <h3>Tasks and Workers</h3>
-            <a href="all/workers-plot.png"><img alt="" src="all/workers-plot.png"/></a>
-            <a href="all/turnover-hist.png"><img alt="" src="all/turnover-hist.png"/></a>
-            <a href="all/worker-deaths-hist.png"><img alt="" src="all/worker-deaths-hist.png"/></a>
-            <a href="all/tasks-plot.png"><img alt="" src="all/tasks-plot.png"/></a>
+            <a href="all/workers-plot.pdf"><img alt="" src="all/workers-plot.png"/></a>
+            <a href="all/turnover-hist.pdf"><img alt="" src="all/turnover-hist.png"/></a>
+            <a href="all/worker-deaths-hist.pdf"><img alt="" src="all/worker-deaths-hist.png"/></a>
+            <a href="all/tasks-plot.pdf"><img alt="" src="all/tasks-plot.png"/></a>
             <h3>Resources</h3>
-            <a href="all/cores-plot.png"><img alt="" src="all/cores-plot.png"/></a>
-            <a href="all/memory-plot.png"><img alt="" src="all/memory-plot.png"/></a>
-            <a href="all/disk-plot.png"><img alt="" src="all/disk-plot.png"/></a>
+            <a href="all/cores-plot.pdf"><img alt="" src="all/cores-plot.png"/></a>
+            <a href="all/memory-plot.pdf"><img alt="" src="all/memory-plot.png"/></a>
+            <a href="all/disk-plot.pdf"><img alt="" src="all/disk-plot.png"/></a>
             <h3>Time Breakdown</h3>
-            <a href="all/lobster-fraction-stack.png"><img alt="" src="all/lobster-fraction-stack.png"/></a>
-            <a href="all/wq-fraction-stack.png"><img alt="" src="all/wq-fraction-stack.png"/></a>
-            <a href="all/return-fraction-stack.png"><img alt="" src="all/return-fraction-stack.png"/></a>
+            <a href="all/lobster-fraction-stack.pdf"><img alt="" src="all/lobster-fraction-stack.png"/></a>
+            <a href="all/wq-fraction-stack.pdf"><img alt="" src="all/wq-fraction-stack.png"/></a>
+            <a href="all/return-fraction-stack.pdf"><img alt="" src="all/return-fraction-stack.png"/></a>
             <h3>Output Performance</h3>
             {% if good_tasks %}
-            <a href="all/output-hist.png"><img alt="" src="all/output-hist.png"/></a>
-            <a href="all/output-total-plot.png"><img alt="" src="all/output-total-plot.png"/></a>
-            <a href="units-total-plot.png"><img alt="" src="units-total-plot.png"/></a>
+            <a href="all/output-hist.pdf"><img alt="" src="all/output-hist.png"/></a>
+            <a href="all/output-total-plot.pdf"><img alt="" src="all/output-total-plot.png"/></a>
+            <a href="units-total-plot.pdf"><img alt="" src="units-total-plot.png"/></a>
             {% else %}
             <p>No output yet!</p>
             {% endif %}
@@ -167,19 +167,19 @@
         <h1>Foreman Summary</h1>
         <span id="foremanmore" class="button depressed"><a href="#" id="foremanmore">Individual Foreman Summaries</a></span>
         <div style="margin-left:410px;">
-            <a href="foreman-tasks-plot.png"><img alt="" src="foreman-tasks-plot.png"/></a>
-            <a href="foreman-idle-plot.png"><img alt="" src="foreman-idle-plot.png"/></a>
-            <a href="foreman-efficiency-plot.png"><img alt="" src="foreman-efficiency-plot.png"/></a>
+            <a href="foreman-tasks-plot.pdf"><img alt="" src="foreman-tasks-plot.png"/></a>
+            <a href="foreman-idle-plot.pdf"><img alt="" src="foreman-idle-plot.png"/></a>
+            <a href="foreman-efficiency-plot.pdf"><img alt="" src="foreman-efficiency-plot.png"/></a>
         </div>
 
         {% for foreman in foremen %}
         <div class="foreman more"><h1>{{ foreman }} summary</h1></div>
         <div class="foreman more" style="float:left">
-            <a href="{{ foreman }}-time-pie.png"><img alt="" src="{{ foreman }}-time-pie.png"/></a>
+            <a href="{{ foreman }}-time-pie.pdf"><img alt="" src="{{ foreman }}-time-pie.png"/></a>
         </div>
         <div class="foreman more" style="margin-left:410px;"><ul class = "img-list">
-            <a href="{{ foreman }}-workers-plot.png"><img alt="" src="{{ foreman }}-workers-plot.png"/></a>
-            <a href="{{ foreman }}-turnover-hist.png"><img alt="" src="{{ foreman }}-turnover-hist.png"/></a>
+            <a href="{{ foreman }}-workers-plot.pdf"><img alt="" src="{{ foreman }}-workers-plot.png"/></a>
+            <a href="{{ foreman }}-turnover-hist.pdf"><img alt="" src="{{ foreman }}-turnover-hist.png"/></a>
         </ul></div>
         {% endfor %}
         {% endif %}

--- a/lobster/commands/data/styles.css
+++ b/lobster/commands/data/styles.css
@@ -191,11 +191,11 @@ span.text-content {
     color: white;
     display: table;
     font-size: 1.5em;
-    height: 150px;
-    left: 15px;
+    height: 160px;
+    left: -15px;
     position: absolute;
     top: -5px;
-    width: 750px;
+    width: 830px;
     opacity: 0;
     -webkit-transition: opacity 500ms;
     -moz-transition: opacity 500ms;

--- a/lobster/commands/plot.py
+++ b/lobster/commands/plot.py
@@ -264,8 +264,12 @@ def mp_plot(a, xlabel, stub=None, ylabel='tasks', bins=50, modes=None, ymax=None
                     ha="center", transform=ax.transAxes, backgroundcolor='white')
 
         if 'label' in kwargs or 'labels' in kwargs:
-            ax.legend(bbox_to_anchor=(0.5, 0.9), loc='lower center', ncol=len(
-                kwargs.get('label', kwargs.get('labels'))), prop={'size': 7}, numpoints=1)
+            ax.legend(bbox_to_anchor=(.5, .95),
+                      frameon=False,
+                      loc='lower center',
+                      ncol=len(kwargs.get('label', kwargs.get('labels'))),
+                      numpoints=1,
+                      prop={'size': 7})
 
         mp_pickle(plotdir, filename, data)
         mp_saveimg(plotdir, filename)

--- a/lobster/commands/plot.py
+++ b/lobster/commands/plot.py
@@ -344,11 +344,12 @@ def mp_plot(a, xlabel, stub=None, ylabel='tasks', bins=50, modes=None, ymax=None
                 var = np.std(y)
                 med = np.median(y)
                 stats[label] = (avg, var, med)
-            info = u"{0} μ = {1:.3g}, σ = {2:.3g} median = {3:.3g}"
-            ax.text(0.75, 0.6,
-                    '\n'.join([info.format(label + ':', avg, var, med)
-                               for label, (avg, var, med) in stats.items()]),
-                    ha="center", transform=ax.transAxes, backgroundcolor='white')
+            info = u"{0}μ = {1:.3g}, σ = {2:.3g}, median = {3:.3g}"
+            t = ax.text(0.75, 0.7,
+                        '\n'.join([info.format(label + ': ' if len(stats) > 1 else '', avg, var, med)
+                                   for label, (avg, var, med) in stats.items()]),
+                        ha="center", va="center", transform=ax.transAxes, backgroundcolor='w')
+            t.set_bbox({'color': 'w', 'alpha': .5, 'edgecolor': 'w'})
 
         if 'label' in kwargs or 'labels' in kwargs:
             ax.legend(bbox_to_anchor=(.5, .95),

--- a/lobster/commands/plot.py
+++ b/lobster/commands/plot.py
@@ -193,7 +193,7 @@ def smooth_data(a):
 
 def mp_plot(a, xlabel, stub=None, ylabel='tasks', bins=50, modes=None, ymax=None, xmin=None, xmax=None, plotdir=None, **kwargs):
     if not modes:
-        modes = [Plotter.HIST, Plotter.PROF | Plotter.TIME]
+        modes = [Plotter.PROF | Plotter.TIME, Plotter.HIST]
 
     paper = kwargs.pop('paper', False)
 

--- a/lobster/commands/plot.py
+++ b/lobster/commands/plot.py
@@ -366,7 +366,7 @@ def mp_saveimg(plotdir, name):
     logger.info("Saving {0}".format(name))
 
     plt.savefig(os.path.join(plotdir, name + '.png'))
-    # plt.savefig(os.path.join(self.__plotdir, name + '.pdf'))
+    plt.savefig(os.path.join(plotdir, name + '.pdf'))
 
     plt.close()
 


### PR DESCRIPTION
Adds a black & white compatible "paper" mode.  Changes:

* produce and link to PDFs by default
* tune legend to not overlap with plot area
* paper mode has smoothing of lines to ensure that we can distinguish different line-styles

Example of [paper mode](http://www.crc.nd.edu/~mwolf3/lobster/ttH/chep_v5/) and [updated regular plotting](http://www.crc.nd.edu/~mwolf3/lobster/ttH/chep_v5_color).