### PR TITLE
Determine and set scram arch from the sandboxes shipped.

### DIFF
--- a/lobster/cmssw/sandbox.py
+++ b/lobster/cmssw/sandbox.py
@@ -52,8 +52,7 @@ class Sandbox(lobster.core.Sandbox):
         path of a release.
         """
         p = os.path.abspath(os.path.expandvars(os.path.expanduser(indir)))
-        version = arch.split('_', 1)[0]
-        return "sandbox-{r}-{v}-{d}.tar.bz2".format(r=rel, v=version, d=hashlib.sha1(p).hexdigest()[:7])
+        return "sandbox-{r}-{v}-{d}.tar.bz2".format(r=rel, v=arch, d=hashlib.sha1(p).hexdigest()[:7])
 
     def __dontpack(self, fn):
         res = ('/.' in fn and '/.SCRAM' not in fn) or '/CVS/' in fn

--- a/lobster/cmssw/sandbox.py
+++ b/lobster/cmssw/sandbox.py
@@ -61,15 +61,12 @@ class Sandbox(lobster.core.Sandbox):
         return False
 
     def _recycle(self, outdir):
-        release_and_arch = re.compile(r'([^/]+)/.SCRAM/(slc[^/]+)')
+        release_and_arch = re.compile(r'sandbox-(.*)-(slc.*)-[A-Fa-f0-9]*.tar.bz2$')
         shutil.copy2(self.recycle, outdir)
-        for f in tarfile.open(self.recycle):
-            m = release_and_arch.search(f.name)
-            if m:
-                rtname, rtarch = m.groups()
-                break
-        else:
+        m = release_and_arch.search(self.recycle)
+        if not m:
             raise AttributeError("Can't determine CMSSW release and arch from recycled sandbox!")
+        rtname, rtarch = m.groups()
         return rtname, rtarch, os.path.join(outdir, os.path.split(self.recycle)[-1])
 
     def _get_cmssw_arch(self, dirname):
@@ -110,7 +107,7 @@ class Sandbox(lobster.core.Sandbox):
         tarball = tarfile.open(outfile, "w|bz2")
 
         # package bin, etc
-        subdirs = ['.SCRAM', 'bin', 'cfipython', 'external', 'lib', 'python']
+        subdirs = ['bin', 'cfipython', 'external', 'lib', 'python']
         subdirs += [os.path.join('src', incl) for incl in self.include]
 
         for (path, dirs, files) in os.walk(os.path.join(indir, 'src')):

--- a/lobster/core/data/wrapper.sh
+++ b/lobster/core/data/wrapper.sh
@@ -148,9 +148,7 @@ export SCRAM_ARCH=$arch
 scramv1 project -f CMSSW $LOBSTER_CMSSW_VERSION || exit_on_error $? 173 "Failed to create new release"
 
 log "unpacking sandbox-${LOBSTER_CMSSW_VERSION}-${arch}.tar.bz2"
-for d in bin cfipython external lib python src; do
-	tar xjf sandbox-${LOBSTER_CMSSW_VERSION}-${arch}.tar.bz2 $LOBSTER_CMSSW_VERSION/$d || exit_on_error $? 170 "Failed to unpack sandbox!"
-done
+tar xjf sandbox-${LOBSTER_CMSSW_VERSION}-${arch}.tar.bz2 || exit_on_error $? 170 "Failed to unpack sandbox!"
 
 basedir=$PWD
 cd $LOBSTER_CMSSW_VERSION

--- a/lobster/core/data/wrapper.sh
+++ b/lobster/core/data/wrapper.sh
@@ -127,9 +127,11 @@ fi
 log "sourcing CMS setup"
 source /cvmfs/cms.cern.ch/cmsset_default.sh || exit_on_error $? 175 "Failed to source CMS"
 
+slc=$(egrep "Red Hat Enterprise|Scientific|CentOS" /etc/redhat-release | sed 's/.*[rR]elease \([0-9]*\).*/\1/')
+arch=$(echo sandbox-${LOBSTER_CMSSW_VERSION}-slc${slc}*.tar.bz2 | grep -oe "slc${slc}_[^.]*")
+
 if [ -z "$LOBSTER_PROXY_INFO" -o \( -z "$LOBSTER_LCG_CP" -a -z "$LOBSTER_GFAL_COPY" \) ]; then
 	log "sourcing OSG setup"
-	slc=$(egrep "Red Hat Enterprise|Scientific|CentOS" /etc/redhat-release | sed 's/.*[rR]elease \([0-9]*\).*/\1/')
 	source /cvmfs/oasis.opensciencegrid.org/osg-software/osg-wn-client/"$LOBSTER_OSG_VERSION"/current/el$slc-$(uname -m)/setup.sh || exit_on_error $? 175 "Failed to source OSG"
 
 	[ -z "$LOBSTER_LCG_CP" ] && export LOBSTER_LCG_CP=$(command -v lcg-cp)
@@ -140,14 +142,14 @@ log "env" "environment after sourcing startup scripts" env
 log "proxy" "proxy information" env X509_USER_PROXY=proxy voms-proxy-info
 log "dir" "working directory at startup" ls -l
 
-log "creating new release $LOBSTER_CMSSW_VERSION"
+log "creating new release $LOBSTER_CMSSW_VERSION for scram arch $arch"
 
+export SCRAM_ARCH=$arch
 scramv1 project -f CMSSW $LOBSTER_CMSSW_VERSION || exit_on_error $? 173 "Failed to create new release"
-arch=$(ls $LOBSTER_CMSSW_VERSION/.SCRAM/|grep slc) || exit_on_error $? 171 "Failed to determine SL release!"
 
-log "unpacking sandbox-${LOBSTER_CMSSW_VERSION}-${arch%%_*}.tar.bz2"
+log "unpacking sandbox-${LOBSTER_CMSSW_VERSION}-${arch}.tar.bz2"
 for d in bin cfipython external lib python src; do
-	tar xjf sandbox-${LOBSTER_CMSSW_VERSION}-${arch%%_*}.tar.bz2 $LOBSTER_CMSSW_VERSION/$d || exit_on_error $? 170 "Failed to unpack sandbox!"
+	tar xjf sandbox-${LOBSTER_CMSSW_VERSION}-${arch}.tar.bz2 $LOBSTER_CMSSW_VERSION/$d || exit_on_error $? 170 "Failed to unpack sandbox!"
 done
 
 basedir=$PWD

--- a/test/test_cmssw_sandbox.py
+++ b/test/test_cmssw_sandbox.py
@@ -33,3 +33,18 @@ class TestSandbox(unittest.TestCase):
         version, arch, box = sandbox.package([os.path.dirname(__file__)], self.workdir)
         files = [f.name for f in tarfile.open(box)]
         assert 'CMSSW_2_3_4/src/Foo/mydir' in files
+
+    def test_recycle(self):
+        sandbox = lobster.cmssw.sandbox.Sandbox(release='data/sandbox/CMSSW_1_2_3', include=['Foo/mydir'])
+        version, arch, box = sandbox.package([os.path.dirname(__file__)], self.workdir)
+
+        tmpdir = os.path.join(self.workdir, 'tmpbox')
+        os.makedirs(tmpdir)
+        shutil.move(box, tmpdir)
+        box = os.path.join(tmpdir, os.path.basename(box))
+
+        sandbox2 = lobster.cmssw.sandbox.Sandbox(recycle=box)
+        version2, arch2, box2 = sandbox2.package([os.path.dirname(__file__)], self.workdir)
+
+        assert version2 == version
+        assert arch2 == arch


### PR DESCRIPTION
Fixes #547.

@WenzhaoLi, @muell149 please test and merge this if it fixes your issues with `scram` not creating the release on the worker. @klannon, too, if this is an issue for you, too.