### PR TITLE
Add build to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 Session.vim
 Lobster.egg-info
 dist/
+build/


### PR DESCRIPTION
Prevent pip's build directory from marking the repo dirty