### PR TITLE
Delete files, even if some do not exist

### DIFF
--- a/lobster/se.py
+++ b/lobster/se.py
@@ -234,11 +234,24 @@ class Hadoop(StorageElement):
         return self.__c.stat([path])['permission']
 
     def remove(self, *paths):
+        """Remove paths.
+
+        First try passing the entire list of paths to be removed. This
+        approach is almost instantaneous, but fails if any of the paths
+        do not exist. In that case, we try again, one by one. This takes
+        tens of milliseconds per path, but ensures that any paths that
+        do exist are removed.
+
+        """
         try:
             for data in self.__c.delete(list(paths)):
                 pass
         except snakebite.errors.FileNotFoundException:
-            pass
+            for path in paths:
+                try:
+                    self.__c.delete([path]).next()
+                except snakebite.errors.FileNotFoundException:
+                    pass
 
 
 class Chirp(StorageElement):


### PR DESCRIPTION
This commit includes two major changes:

1) If the snakebite `remove` call fails because a file is missing, try
   again, one at a time, so that files that do exist are removed.
2) Breaks the `fs.remove` call in two: once for failed tasks, which are
   likely not to exist, and once for merged/input cleanup tasks, which
   are likely to be where we expect them. In that way we usually only
   end up in the `except` clause for failed tasks, which should mitigate
   the slowdown from 1).

Fixes #558.