### PR TITLE
Get WMCore from pypi

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -15,7 +15,6 @@ git clone https://github.com/dmwm/DBS.git "$dir"
 	python setup.py install_system -s pycurl-client
 )
 rm -rf "$dir"
-pip install 'git+https://github.com/dmwm/WMCore@1.0.9.patch2#egg=WMCore-1.0.9.patch2'
 
 if [ -z "$BUILD_CCTOOLS" ]; then
 	exit 0

--- a/lobster/cmssw/dash.py
+++ b/lobster/cmssw/dash.py
@@ -6,7 +6,20 @@ import subprocess
 
 from hashlib import sha1
 
-from WMCore.Services.Dashboard.DashboardAPI import apmonSend, apmonFree
+try:
+    from WMCore.Services.Dashboard.DashboardAPI import apmonSend, apmonFree
+except ImportError:
+    # WMCore changed their API at commit 84953579a
+    from WMCore.Services.Dashboard.DashboardAPI import DashboardAPI
+    def apmonSend(workflowid, taskid, params, logger, conf):
+        with DashboardAPI(logr=logger, apmonServer=conf) as dash:
+            dash.apMonSend(params)
+
+    def apmonFree(*args):
+        # We only create DashboardAPIs in context managers who handle the
+        # freeing of resources, so we don't need to do it explicitly
+        pass
+
 from WMCore.Services.SiteDB.SiteDB import SiteDBJSON
 from WMCore.Storage.SiteLocalConfig import loadSiteLocalConfig, SiteConfigError
 from lobster import util

--- a/setup.py
+++ b/setup.py
@@ -54,10 +54,7 @@ setup(
         'requests',
         'retrying',
         'snakebite<2.0',
-        'WMCore'
-    ],
-    dependency_links=[
-        'git+https://github.com/dmwm/WMCore@1.0.9.patch2#egg=WMCore-1.0.9.patch2'
+        'wmcore>=1.1.1.pre7'
     ],
     entry_points={
         'console_scripts': ['lobster = lobster.ui:boil']


### PR DESCRIPTION
I put in a corresponding patch to WMCore to get it into pypi so it can be treated like another regular dependency. This code:

* Update the lobster usage of the Dashboard API to match the new WMCore API
* Remove WMCore from install_dependencies.sh and add to setup.py

Verified by checking out this branch and installing to a blank venv:
```
$ pip install -U .
<snip>
Successfully installed Lobster-1.5-8ceccfc-clean argparse-1.4.0 cycler-0.10.0 docutils-0.13.1 elasticsearch-5.2.0 elasticsearch-dsl-5.1.0 functools32-3.2.3-2 httplib2-0.10.3 jinja2-2.9.5 lockfile-0.12.2 matplotlib-2.0.0 nose-1.3.7 numpy-1.12.0 protobuf-3.2.0 psutil-5.1.3 pyparsing-2.1.10 python-cjson-1.2.1 python-daemon-2.1.2 python-dateutil-2.6.0 pytz-2016.10 pyxdg-0.25 requests-2.13.0 retrying-1.3.3 setuptools-34.3.0 snakebite-1.3.13 subprocess32-3.2.7 urllib3-1.20 wmcore-1.1.1rc7
```

I tested the dashboard functionality by running `lobster status` on an existing task. Additionally, there may be some deps that are needed only transitively by WMCore. Those can be cleaned up later.

I'm working on the equivalent change for the DBS client API.