### PR TITLE
Fix logic in cleanup file list assembly

### DIFF
--- a/lobster/core/source.py
+++ b/lobster/core/source.py
@@ -507,7 +507,7 @@ class TaskProvider(util.Timing):
                 self.__store.update_units(update)
 
         with self.measure('cleanup'):
-            if wflow.cleanup_input and len(input_files) > 0:
+            if len(input_files) > 0:
                 input_cleanup.extend(self.__store.finished_files(input_files))
 
             for cleanup in [fail_cleanup, merge_cleanup + input_cleanup]:


### PR DESCRIPTION
I spotted this in passing. It looks wrong to me-- some returned workflows might have cleanup enabled and others disabled, but we're only checking the last workflow in the preceding loop. I think we just care if it's been populated at any point.