### PR TITLE
Deduplicate units stuck

### DIFF
--- a/lobster/commands/data/category.html
+++ b/lobster/commands/data/category.html
@@ -154,8 +154,8 @@
 		<th>
 		    <div class="tooltip">stuck
 		        <span class="tooltiptext">
-			    Units which cannot be attempted because their input is a unit in a parent workflow that failed
-			    or was skipped.
+			    Units which cannot be attempted because they are either failed or skipped, or their input is
+			    a unit in a parent workflow that failed or was skipped.
 
 			    If you want to increase skipping/failure thresholds so that the parent units are attempted
 			    again, run <span class="code">lobster configure /my/working/directory</span> and increase

--- a/lobster/commands/data/index.html
+++ b/lobster/commands/data/index.html
@@ -113,8 +113,8 @@
 		<th>
 		    <div class="tooltip">stuck
 		        <span class="tooltiptext">
-			    Units which cannot be attempted because their input is a unit in a parent workflow that failed
-			    or was skipped.
+			    Units which cannot be attempted because they are either failed or skipped, or their input is
+			    a unit in a parent workflow that failed or was skipped.
 
 			    If you want to increase skipping/failure thresholds so that the parent units are attempted
 			    again, run <span class="code">lobster configure /my/working/directory</span> and increase

--- a/lobster/util.py
+++ b/lobster/util.py
@@ -23,7 +23,7 @@ from contextlib import contextmanager
 from email.mime.text import MIMEText
 from pkg_resources import get_distribution
 
-VERSION = "1.5"
+VERSION = "1.6"
 
 logger = logging.getLogger('lobster.util')
 


### PR DESCRIPTION
Under some conditions a unit can satisfy both being failed and being
skipped. In those cases we double-count how many units are stuck (this
error was introduced by me in c98a5bb). This commit reverts back to
calculating the union of stuck and failed rather than the sum. It also
changes the definition of 'stuck' given in workflow summary to be in
line with what we use under-the-hood (so for users, stuck goes from
"parent stuck" to "parent stuck or skipped or failed". I think the
former use is more straightforward for users, but maintaining a separate
definition is too confusing. Fixes #592.

To continue reporting the units failed and units stuck every time we run `update_workflow_stats`, we'd need to compute both the units failed, units skipped, and the union of those lists. To keep the computation lean, I went back to only calculating the union (and removing the units_failed and units_skipped columns from the workflow table). Now units_failed and units_skipped is only calculated when we call `workflow_status` (during plotting and when running `lobster status`). This isn't a complete reversion of c98a5bb though, there are still some minor improvements in readability. 

The new method is slightly slower than before, but should be equivalent to the speed pre-c98a5bb:
```
In [1]: from lobster.core import unit
In [2]: import imp
In [3]: cfg = imp.load_source('cfg', 'config.py').config
In [4]: store = unit.UnitStore(cfg)
```
NEW:
```
In [5]: %timeit store.update_workflow_stats('ttW_extn')
10 loops, best of 3: 26.9 ms per loop
```
OLD:
```
In [6]: %autoreload
In [7]: %timeit store.update_workflow_stats('ttW_extn')
10 loops, best of 3: 23 ms per loop
```
NEW:
![screen shot 2017-05-27 at 1 22 26 pm](https://cloud.githubusercontent.com/assets/5114833/26523596/c3f39682-42e0-11e7-9f4f-d50c018c708b.png)

OLD:
![screen shot 2017-05-27 at 12 01 40 am](https://cloud.githubusercontent.com/assets/5114833/26523594/b36398f8-42e0-11e7-8f56-9be9080b8072.png)

- [x] Has the database format changed? (renamed or new columns, tables)
  Or did any of the project layout change? (files required to run the
  workflows)
  - Please increase the version number `VERSION` after the imports in
    `lobster.util`.  This will ensure that Lobster does not try to load old
    projects with an incompatible version. -> DONE