### PR TITLE
Allow WQ port customization.

### DIFF
--- a/lobster/commands/process.py
+++ b/lobster/commands/process.py
@@ -192,7 +192,7 @@ class Process(Command, util.Timing):
         wq.cctools_debug_config_file(os.path.join(self.config.workdir, "work_queue_debug.log"))
         wq.cctools_debug_config_file_size(1 << 29)
 
-        self.queue = wq.WorkQueue(-1)
+        self.queue = wq.WorkQueue(self.config.advanced.wq_port)
         self.queue.specify_min_taskid(self.source.max_taskid() + 1)
         self.queue.specify_log(os.path.join(self.config.workdir, "work_queue.log"))
         self.queue.specify_transactions_log(os.path.join(self.config.workdir, "transactions.log"))

--- a/lobster/core/config.py
+++ b/lobster/core/config.py
@@ -201,6 +201,9 @@ class AdvancedOptions(Configurable):
             How often `WorkQueue` will attempt to process a task before
             handing it back to Lobster.  `WorkQueue` will only reprocess
             evicted tasks automatically.
+        wq_port : int
+            WorkQueue Master port number.
+            Defaults to -1 to look for an available port.
         xrootd_servers : list
             A list of xrootd servers to use to access remote data.
             Defaults to `cmsxrootd.fnal.gov`.
@@ -229,6 +232,7 @@ class AdvancedOptions(Configurable):
                  threshold_for_failure=30,
                  threshold_for_skipping=30,
                  wq_max_retries=10,
+                 wq_port=-1,
                  xrootd_servers=None):
         from lobster import cmssw
 
@@ -257,4 +261,5 @@ class AdvancedOptions(Configurable):
         self.threshold_for_failure = threshold_for_failure
         self.threshold_for_skipping = threshold_for_skipping
         self.wq_max_retries = wq_max_retries
+        self.wq_port = wq_port
         self.xrootd_servers = xrootd_servers if xrootd_servers else ['cmsxrootd.fnal.gov']


### PR DESCRIPTION
This is useful if you need your master to be on a specific port number (e.g: an open TCP port, so workers from outside your local network can connect without ssh-tunnels or other tricks).

I wasn't sure where to put that, so I added it as an advanced parameter and kept the "-1" as default.