### PR TITLE
Add "IndexError" to the list of errors in the siteconf frontier try-except clause

### DIFF
--- a/lobster/core/source.py
+++ b/lobster/core/source.py
@@ -111,7 +111,7 @@ class TaskProvider(util.Timing):
             self.__ce = siteconf.siteName
             self.__se = siteconf.localStageOutPNN()
             self.__frontier_proxy = siteconf.frontierProxies[0]
-        except SiteConfigError:
+        except (SiteConfigError, IndexError):
             logger.error("can't load siteconfig, defaulting to hostname")
             self.__ce = socket.getfqdn()
             self.__se = socket.getfqdn()


### PR DESCRIPTION
Sometimes, SITECONF might exist without a frontier proxy defined, so `siteconf.frontierProxies[0]` will fail with "IndexError: Out of range".