### PR TITLE
Shuffle paths around better and fix test complaints.

### DIFF
--- a/lobster/core/source.py
+++ b/lobster/core/source.py
@@ -124,7 +124,7 @@ class TaskProvider(util.Timing):
         try:
             with open('/etc/cvmfs/default.local') as f:
                 lines = f.readlines()
-        except:
+        except IOError:
             lines = []
         for l in lines:
             m = re.match('\s*CVMFS_HTTP_PROXY\s*=\s*[\'"]?(.*)[\'"]?', l)

--- a/test/count_events.py
+++ b/test/count_events.py
@@ -22,13 +22,13 @@ for path in args.paths:
     events[path] = np.zeros(args.max, dtype='int32, int32, int32')
     for index, event in enumerate(DataFormats.FWLite.Events(files)):
         r = event.object().id().run()
-        l = event.object().id().luminosityBlock()
+        b = event.object().id().luminosityBlock()
         e = event.object().id().event()
 
-        events[path][index] = (r, l, e)
+        events[path][index] = (r, b, e)
 
         if args.verbose and index % 5000 == 0:
-            print '>>>> entry run lumi event: {:10} {:10} {:10} {:10}'.format(index, r, l, e)
+            print '>>>> entry run lumi event: {:10} {:10} {:10} {:10}'.format(index, r, b, e)
 
         if index == args.max:
             break


### PR DESCRIPTION
The former is motivated by @Andrew42's trouble to install Lobster, where
something loads the wrong six package, irrespective of the sys.path
manipulation we did before. Turns out there is a sys.meta_path that affects
package loading.

Also fix the python style complaints from CI.

Please make sure that the following items are taken care of if needed:

- [x] Has the database format changed? (renamed or new columns, tables)
  Or did any of the project layout change? (files required to run the
  workflows)
  - Please increase the version number `VERSION` after the imports in
    `lobster.util`.  This will ensure that Lobster does not try to load old
    projects with an incompatible version.
- [x] Did the required _Work Queue_ version change?
  - Please update the *three* version numbers in `doc/install.rst`.  Adjust
    the tarball name in the `install_dependecies.sh` script, too.
- [x] Are all additional dependencies in `setup.py`?
- [x] [Mark any issues as closed either in commits or in this pull
  request.](https://help.github.com/articles/closing-issues-via-commit-messages/)
