### PR TITLE
Allow adjustable tasksizes for prod workflows

### DIFF
--- a/examples/mc_gen.py
+++ b/examples/mc_gen.py
@@ -25,9 +25,9 @@ lhe = Workflow(
     sandbox=cmssw.Sandbox(release='mc_gen/CMSSW_7_1_16_patch1'),
     merge_size='125M',
     dataset=ProductionDataset(
-        events_per_task=250,
+        total_events=25000,
         events_per_lumi=25,
-        number_of_tasks=100
+        lumis_per_task=10
     ),
     category=Category(
         name='lhe',

--- a/lobster/core/task.py
+++ b/lobster/core/task.py
@@ -289,6 +289,7 @@ class ProductionTaskHandler(TaskHandler):
     def adjust(self, parameters, inputs, outputs, se):
         super(ProductionTaskHandler, self).adjust(parameters, inputs, outputs, se)
         parameters['mask']['first lumi'] = self._units[0][3]
+        parameters['mask']['events'] = parameters['mask']['events per lumi'] * len(self._units)
 
     def get_unit_info(self, failed, task_update, files_info, files_skipped, events_written):
         _, up = super(ProductionTaskHandler, self).get_unit_info(failed, task_update, files_info, files_skipped, events_written)

--- a/lobster/core/workflow.py
+++ b/lobster/core/workflow.py
@@ -472,7 +472,6 @@ class Workflow(Configurable):
         params['executable'] = cmd
         params['arguments'] = args
         if isinstance(self.dataset, ProductionDataset) and not merge:
-            params['mask']['events'] = self.dataset.events_per_task
             params['mask']['events per lumi'] = self.dataset.events_per_lumi
             params['randomize seeds'] = self.dataset.randomize_seeds
         else:

--- a/lobster/util.py
+++ b/lobster/util.py
@@ -23,7 +23,7 @@ from contextlib import contextmanager
 from email.mime.text import MIMEText
 from pkg_resources import get_distribution
 
-VERSION = "1.6"
+VERSION = "1.7"
 
 logger = logging.getLogger('lobster.util')
 


### PR DESCRIPTION
Before, users could specify `events_per_task`, `events_per_lumi` (optionally) and `number_of_tasks`. The tasksize adjusts to meet the requested runtime, but has no effect on the number of events processed per task. This changes the dataset specification to `total_events` (what the user ultimately cares about), `events_per_lumi`, and `lumis_per_task` and adjusts `events_per_task` according to the tasksize. In this way, adjustable tasksizes have the same effect as for non-prod workflows.


- [x] Has the database format changed? (renamed or new columns, tables)
  Or did any of the project layout change? (files required to run the
  workflows)
  - Please increase the version number `VERSION` after the imports in
    `lobster.util`.  This will ensure that Lobster does not try to load old
    projects with an incompatible version.
- [x] Did the required _Work Queue_ version change?
  - Please update the *three* version numbers in `doc/install.rst`.  Adjust
    the tarball name in the `install_dependecies.sh` script, too.
- [x] Are all additional dependencies in `setup.py`?
- [x] [Mark any issues as closed either in commits or in this pull
  request.](https://help.github.com/articles/closing-issues-via-commit-messages/)
