### PR TITLE
Fix silent crashes

### DIFF
--- a/lobster/core/task.py
+++ b/lobster/core/task.py
@@ -314,9 +314,6 @@ class MultiProductionTaskHandler(ProductionTaskHandler):
         skipped = 0
         file_update = [(events_read, skipped, id)]
 
-        logger.debug('in multi production handler\nfailed: {0}\nfiles_info: {1}\nfiles_skipped: {2}\nevents_written: {3}'.format(
-            failed, files_info, files_skipped, events_written))
-
         if failed:
             events_written = 0
             status = unit.FAILED

--- a/lobster/core/workflow.py
+++ b/lobster/core/workflow.py
@@ -315,7 +315,8 @@ class Workflow(Configurable):
                 elif os.path.isdir(source):
                     shutil.copytree(source, target)
                 else:
-                    raise NotImplementedError
+                    logger.error("no such file or directory: {}".format(source))
+                    sys.exit(1)
 
             return target
 

--- a/lobster/core/workflow.py
+++ b/lobster/core/workflow.py
@@ -180,10 +180,10 @@ class Workflow(Configurable):
             CMSSW workflows, and can be automatically determined for these.
         merge_command : str
             Accepts `cmsRun`, `hadd`, or a custom command. Tells Lobster what
-            command to use for merging. If outputs are autodetermined, cmssw
-            will be used for EDM output and hadd will be used otherwise. Custom
-            commands should accept the output file as the first argument followed
-            by one or more input files to merge.
+            command to use for merging. If outputs are autodetermined
+            (`outputs=None`), cmssw will be used for EDM output and hadd will
+            be used otherwise. Custom commands should accept the output file
+            as the first argument followed by one or more input files to merge.
     """
     _mutable = {}
 

--- a/lobster/ui.py
+++ b/lobster/ui.py
@@ -50,7 +50,10 @@ def boil():
                 cfg.base_configuration = os.path.abspath(args.checkpoint)
                 cfg.startup_directory = os.path.abspath(os.getcwd())
                 for w in cfg.workflows:
-                    w.validate()
+                    try:
+                        w.validate()
+                    except Exception as e:
+                        parser.error("configuration '{0}' failed validation: {1}".format(args.checkpoint, e))
         else:
             parser.error("""
                 Cannot find working directory at '{0}'.


### PR DESCRIPTION
This fixes two error modes which were causing silent crashes when not in foreground mode. For cases when the user specifies non-existent `extra_inputs`, it is not straightforward to get that check to happen before making the working directory without substantial reshuffling, so I think it makes sense to exit right away anyways instead of raising. Also: miscellaneous minor tweaks.


- [x] Has the database format changed? (renamed or new columns, tables)
  Or did any of the project layout change? (files required to run the
  workflows)
  - Please increase the version number `VERSION` after the imports in
    `lobster.util`.  This will ensure that Lobster does not try to load old
    projects with an incompatible version.
- [x] Did the required _Work Queue_ version change?
  - Please update the *three* version numbers in `doc/install.rst`.  Adjust
    the tarball name in the `install_dependecies.sh` script, too.
- [x] Are all additional dependencies in `setup.py`?
- [x] [Mark any issues as closed either in commits or in this pull
  request.](https://help.github.com/articles/closing-issues-via-commit-messages/)
